### PR TITLE
Bounded queue for a task executor

### DIFF
--- a/atlas-index-api/src/main/java/uk/ac/ebi/gxa/statistics/Statistics.java
+++ b/atlas-index-api/src/main/java/uk/ac/ebi/gxa/statistics/Statistics.java
@@ -92,7 +92,7 @@ public class Statistics implements Serializable, StatisticsBuilder {
     @Override
     public void addStatistics(final Integer attributeIndex,
                               final Integer experimentIndex,
-                              final Collection<Integer> bioEntityIds) {
+                              final ConciseSet bioEntityIds) {
 
         Map<Integer, ConciseSet> attributeStats = statistics.get(attributeIndex);
         if (attributeStats == null) {
@@ -101,7 +101,7 @@ public class Statistics implements Serializable, StatisticsBuilder {
 
         final ConciseSet experimentBioEntities = attributeStats.get(experimentIndex);
         if (experimentBioEntities == null) {
-            attributeStats.put(experimentIndex, new ConciseSet(bioEntityIds));
+            attributeStats.put(experimentIndex, bioEntityIds);
         } else {
             experimentBioEntities.addAll(bioEntityIds);
         }
@@ -118,11 +118,11 @@ public class Statistics implements Serializable, StatisticsBuilder {
      */
     @Override
     public void addBioEntitiesForEfAttribute(final Integer attributeIndex,
-                                             final Collection<Integer> bioEntityIds) {
+                                             final ConciseSet bioEntityIds) {
 
         final ConciseSet efBioEntities = efAttributeToBioEntities.get(attributeIndex);
         if (efBioEntities == null) {
-            efAttributeToBioEntities.put(attributeIndex, new ConciseSet(bioEntityIds));
+            efAttributeToBioEntities.put(attributeIndex, bioEntityIds);
         } else {
             efBioEntities.addAll(bioEntityIds);
         }
@@ -136,11 +136,11 @@ public class Statistics implements Serializable, StatisticsBuilder {
      */
     @Override
     public void addBioEntitiesForEfvAttribute(final Integer attributeIndex,
-                                              final Collection<Integer> bioEntityIds) {
+                                              final ConciseSet bioEntityIds) {
 
         final ConciseSet efvBioEntities = efvAttributeToBioEntities.get(attributeIndex);
         if (efvBioEntities == null) {
-            efvAttributeToBioEntities.put(attributeIndex, new ConciseSet(bioEntityIds));
+            efvAttributeToBioEntities.put(attributeIndex, bioEntityIds);
         } else {
             efvBioEntities.addAll(bioEntityIds);
         }

--- a/atlas-index-api/src/main/java/uk/ac/ebi/gxa/statistics/StatisticsBuilder.java
+++ b/atlas-index-api/src/main/java/uk/ac/ebi/gxa/statistics/StatisticsBuilder.java
@@ -1,15 +1,14 @@
 package uk.ac.ebi.gxa.statistics;
 
 import com.google.common.collect.Multiset;
-
-import java.util.Collection;
+import it.uniroma3.mat.extendedset.ConciseSet;
 
 public interface StatisticsBuilder {
-    void addStatistics(Integer attributeIndex, Integer experimentIndex, Collection<Integer> bioEntityIds);
+    void addStatistics(Integer attributeIndex, Integer experimentIndex, ConciseSet bioEntityIds);
 
-    void addBioEntitiesForEfAttribute(Integer attributeIndex, Collection<Integer> bioEntityIds);
+    void addBioEntitiesForEfAttribute(Integer attributeIndex, ConciseSet bioEntityIds);
 
-    void addBioEntitiesForEfvAttribute(Integer attributeIndex, Collection<Integer> bioEntityIds);
+    void addBioEntitiesForEfvAttribute(Integer attributeIndex, ConciseSet bioEntityIds);
 
     void setScoresAcrossAllEfos(Multiset<Integer> scores);
 

--- a/atlas-index-api/src/main/java/uk/ac/ebi/gxa/statistics/ThreadSafeStatisticsBuilder.java
+++ b/atlas-index-api/src/main/java/uk/ac/ebi/gxa/statistics/ThreadSafeStatisticsBuilder.java
@@ -6,10 +6,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
-import java.util.Queue;
 import java.util.concurrent.*;
 
-import static java.util.concurrent.Executors.callable;
 import static uk.ac.ebi.gxa.exceptions.LogUtil.logUnexpected;
 
 @ThreadSafe
@@ -17,8 +15,8 @@ public class ThreadSafeStatisticsBuilder implements StatisticsBuilder {
     private static final Logger log = LoggerFactory.getLogger(ThreadSafeStatisticsBuilder.class);
 
     private final Statistics statistics = new Statistics();
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
-    private final Queue<Future<Object>> pending = new ConcurrentLinkedQueue<Future<Object>>();
+    private final ExecutorService executor = new ThreadPoolExecutor(1, 1, 1, TimeUnit.SECONDS,
+            new ArrayBlockingQueue<Runnable>(100, false), new BlockOnRejectedExecutionHandler());
 
     @Override
     public void addStatistics(final Integer attributeIndex, final Integer experimentIndex, final Collection<Integer> bioEntityIds) {
@@ -73,30 +71,25 @@ public class ThreadSafeStatisticsBuilder implements StatisticsBuilder {
     @Override
     public Statistics getStatistics() {
         try {
-            for (Future<Object> future : pending) {
-                future.get();
-            }
-        } catch (InterruptedException e) {
-            log.warn("Interrupted, returning incomplete result", e);
+            executor.shutdown();
+            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
             return statistics;
-        } catch (ExecutionException e) {
-            throw logUnexpected("Exception in statistics update", e.getCause());
+        } catch (InterruptedException e) {
+            throw logUnexpected("Interrupted, returning incomplete result", e);
         }
-        return statistics;
     }
 
     private void enqueue(Runnable task) {
-        pending.offer(executor.submit(callable(task)));
+        executor.submit(task);
+    }
 
-        // now we clean up the pending queue off the finished tasks
-        Future<Object> future = pending.peek();
-        while (future != null && future.isDone()) {
-            future = pending.poll();
-            if (future == null)
-                return;
-            if (!future.isDone()) {
-                pending.offer(future);
-                return;
+    private static class BlockOnRejectedExecutionHandler implements RejectedExecutionHandler {
+        @Override
+        public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+            try {
+                executor.getQueue().put(r);
+            } catch (InterruptedException e) {
+                throw logUnexpected("Interrupted: " + e.getMessage(), e);
             }
         }
     }

--- a/atlas-index-api/src/main/java/uk/ac/ebi/gxa/statistics/ThreadSafeStatisticsBuilder.java
+++ b/atlas-index-api/src/main/java/uk/ac/ebi/gxa/statistics/ThreadSafeStatisticsBuilder.java
@@ -1,11 +1,11 @@
 package uk.ac.ebi.gxa.statistics;
 
 import com.google.common.collect.Multiset;
+import it.uniroma3.mat.extendedset.ConciseSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.ThreadSafe;
-import java.util.Collection;
 import java.util.concurrent.*;
 
 import static uk.ac.ebi.gxa.exceptions.LogUtil.logUnexpected;
@@ -19,7 +19,7 @@ public class ThreadSafeStatisticsBuilder implements StatisticsBuilder {
             new ArrayBlockingQueue<Runnable>(100, false), new BlockOnRejectedExecutionHandler());
 
     @Override
-    public void addStatistics(final Integer attributeIndex, final Integer experimentIndex, final Collection<Integer> bioEntityIds) {
+    public void addStatistics(final Integer attributeIndex, final Integer experimentIndex, final ConciseSet bioEntityIds) {
         enqueue(new Runnable() {
             @Override
             public void run() {
@@ -29,7 +29,7 @@ public class ThreadSafeStatisticsBuilder implements StatisticsBuilder {
     }
 
     @Override
-    public void addBioEntitiesForEfAttribute(final Integer attributeIndex, final Collection<Integer> bioEntityIds) {
+    public void addBioEntitiesForEfAttribute(final Integer attributeIndex, final ConciseSet bioEntityIds) {
         enqueue(new Runnable() {
             @Override
             public void run() {
@@ -39,7 +39,7 @@ public class ThreadSafeStatisticsBuilder implements StatisticsBuilder {
     }
 
     @Override
-    public void addBioEntitiesForEfvAttribute(final Integer attributeIndex, final Collection<Integer> bioEntityIds) {
+    public void addBioEntitiesForEfvAttribute(final Integer attributeIndex, final ConciseSet bioEntityIds) {
         enqueue(new Runnable() {
             @Override
             public void run() {

--- a/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/GeneAtlasBitIndexBuilderService.java
+++ b/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/GeneAtlasBitIndexBuilderService.java
@@ -153,7 +153,7 @@ public class GeneAtlasBitIndexBuilderService extends IndexBuilderService {
                     NetCDFProxy ncdf = null;
                     getLog().debug("Processing {}", nc);
                     try {
-                        ncdf = new NetCDFProxy(nc);
+                        ncdf = new NetCDFProxy(nc, false);
                         if (ncdf.isOutOfDate()) {
                             // Fail index build if a given ncdf is out of date
                             return false;

--- a/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/GeneAtlasBitIndexBuilderService.java
+++ b/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/GeneAtlasBitIndexBuilderService.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.io.Closeables.closeQuietly;
 import static java.lang.Math.round;
+import static java.util.Collections.shuffle;
 
 /**
  * Class used to build ConciseSet-based gene expression statistics index
@@ -126,6 +127,7 @@ public class GeneAtlasBitIndexBuilderService extends IndexBuilderService {
         final StatisticsBuilder noStats = new ThreadSafeStatisticsBuilder();
 
         List<File> ncdfs = atlasNetCDFDAO.getAllNcdfs();
+        shuffle(ncdfs);
 
         final AtomicInteger totalStatCount = new AtomicInteger();
         final Integer total = ncdfs.size();

--- a/netcdf-reader/src/main/java/uk/ac/ebi/gxa/netcdf/reader/NetCDFProxy.java
+++ b/netcdf-reader/src/main/java/uk/ac/ebi/gxa/netcdf/reader/NetCDFProxy.java
@@ -86,8 +86,14 @@ public class NetCDFProxy implements Closeable {
     private final NetcdfFile netCDF;
 
     public NetCDFProxy(File file) throws IOException {
+        this(file, true);
+    }
+
+    public NetCDFProxy(File file, boolean cached) throws IOException {
         this.pathToNetCDF = file.getAbsoluteFile();
-        this.netCDF = NetcdfDataset.acquireFile(file.getAbsolutePath(), null);
+        this.netCDF = cached ?
+                NetcdfDataset.acquireFile(file.getAbsolutePath(), null) :
+                NetcdfFile.open(file.getAbsolutePath());
         if (isOutOfDate())
             log.error("ncdf " + getId() + " for experiment: " + getExperiment() + " is out of date - please update it and then recompute its analytics via Atlas administration interface");
     }
@@ -96,7 +102,7 @@ public class NetCDFProxy implements Closeable {
      * @return true if the version inside ncdf file is not the same as NCDF_VERSION; false otherwise
      * @throws IOException
      */
-    public boolean isOutOfDate()  {
+    public boolean isOutOfDate() {
         return !NCDF_VERSION.equals(getNcdfVersion());
     }
 
@@ -313,6 +319,7 @@ public class NetCDFProxy implements Closeable {
 
     /**
      * Returns the whole matrix of factor values for assays (|Assay| X |EF|).
+     *
      * @return an array of strings - an array of factor values per assay
      * @throws IOException if data could not be read form the netCDF file
      */
@@ -444,7 +451,7 @@ public class NetCDFProxy implements Closeable {
      *
      * @param deIndices an array of design element indices to get expression values for
      * @return a float matrix - a list of expressions per design element index
-     * @throws IOException if the expression data could not be read from the netCDF file
+     * @throws IOException           if the expression data could not be read from the netCDF file
      * @throws InvalidRangeException if the file doesn't contain given deIndices
      */
     public FloatMatrixProxy getExpressionValues(int[] deIndices) throws IOException, InvalidRangeException {


### PR DESCRIPTION
temporary solution; it solves the current problem of the queue building up in the memory; it doesn't provide any significant advantage over the simple synchronised approach (well, the colours in profiler are nicer)

(cherry picked from commit 8bfb9b12475f7fee87f54b87f9648280f96b38a8)

Conflicts:
    atlas-index-api/src/main/java/uk/ac/ebi/gxa/statistics/ThreadSafeStatisticsBuilder.java
