### PR TITLE
was -> way

### DIFF
--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/tasks/IndexTask.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/tasks/IndexTask.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 
 /**
  * Index builder tasks implementation. Can (re-)index just one experiment or entire index.
- * Statuses for those two types of tasks interact in a kind of a tricky was. If "index"
+ * Statuses for those two types of tasks interact in a kind of a tricky way. If "index"
  * task status is set to INCOMPLETE, it practically means that all experiments are considered
  * as having invalid index. In turn, any INCOMPLETE indexexperiment means that the whole index could do
  * with rebuilding


### PR DESCRIPTION
a small typo; mainly to check whether it's annoying to review small changes.
