### PR TITLE
Ticket #2957 continue: GenePropValueListHelperTest broken

### DIFF
--- a/atlas-web/src/main/java/ae3/service/structuredquery/AtlasGenePropertyService.java
+++ b/atlas-web/src/main/java/ae3/service/structuredquery/AtlasGenePropertyService.java
@@ -265,7 +265,7 @@ public class AtlasGenePropertyService implements AutoCompleter,
             }
         }
         Collections.sort(result);
-        if (result.size() > limit) {
+        if (limit > 0 && result.size() > limit) {
             result = result.subList(0, limit);
         }
         return result;


### PR DESCRIPTION
The was test was broken, because the limit value was not check for -1.

@rpetry, please review once more :) 
