### PR TITLE
a quick fix for factor name in wiggle URL

### DIFF
--- a/atlas-web/src/main/webapp/scripts/experiment.js
+++ b/atlas-web/src/main/webapp/scripts/experiment.js
@@ -1786,7 +1786,7 @@
                     geneId: ea.geneId,
                     geneIdentifier: ea.geneIdentifier,
                     ef: curatedEFs[ea.ef] || ea.ef,
-                    ef_enc: encodeURIComponent(encodeURIComponent(curatedEFs[ea.ef])).replace(/_/g, '%5F'),
+                    ef_enc: encodeURIComponent(encodeURIComponent(ea.ef)).replace(/_/g, '%5F'),
                     rawef: ea.ef,
                     efv: ea.efv,
                     efv_enc: encodeURIComponent(encodeURIComponent(ea.efv)).replace(/_/g, '%5F'),


### PR DESCRIPTION
So, on the `Organism%20` vs `organism%5f` problem, it's an old can of worms:
- we have weird and obscure mapping from "internal" EF names to nice and shiny "external" names;
- problem is, we do this mapping, well, everywhere and in couple more places
- so when we make EFs too shiny, we have problems like this one.

The fix just removes translation from EF "accession" to "human-readable" EF, as in fact what we looked for was indeed accession.

@rpetry — could you please take a look and merge in?
