### PR TITLE
Double and float formatting, rounded to a proper number of digits

### DIFF
--- a/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/FloatFormatter.java
+++ b/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/FloatFormatter.java
@@ -22,32 +22,12 @@
 
 package uk.ac.ebi.gxa.utils;
 
-import java.text.DecimalFormat;
+import static java.lang.Math.*;
 
 public abstract class FloatFormatter {
     private FloatFormatter() {
     }
 
-    private static DecimalFormat[] formatsCache = new DecimalFormat[10];
-
-    private static DecimalFormat decimalFormat(int numberOfDigits) {
-        DecimalFormat format = null;
-        if (numberOfDigits < 10) {
-            format = formatsCache[numberOfDigits];
-        }
-        if (format == null) {
-            final StringBuilder s = new StringBuilder("#.");
-            for (int i = 0; i < numberOfDigits; ++i) {
-                s.append("#");
-            }
-            format = new DecimalFormat(s.toString());
-            if (numberOfDigits < 10) {
-                formatsCache[numberOfDigits] = format;
-            }
-        }
-        return format;
-    }
- 
     public static String formatFloat(float value, int significantDigits) {
         if (Float.isInfinite(value)) {
             return "null";
@@ -55,9 +35,7 @@ public abstract class FloatFormatter {
         if (Float.isNaN(value)) {
             return "null";
         }
-        return decimalFormat(
-            Math.max(0, significantDigits - (int)Math.ceil(Math.log10(Math.abs(value))))
-        ).format(value);
+        return Double.toString(trimSignificantDigits(value, significantDigits));
     }
 
     public static String formatDouble(double value, int significantDigits) {
@@ -67,8 +45,12 @@ public abstract class FloatFormatter {
         if (Double.isNaN(value)) {
             return "null";
         }
-        return decimalFormat(
-            Math.max(0, significantDigits - (int)Math.ceil(Math.log10(Math.abs(value))))
-        ).format(value);
+        return Double.toString(trimSignificantDigits(value, significantDigits));
+    }
+
+    private static double trimSignificantDigits(double value, int significantDigits) {
+        int order = (int) ceil(log10(abs(value)));
+        final double precision = pow(10.0, order - significantDigits);
+        return round(value / precision) * precision;
     }
 }

--- a/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/FloatFormatter.java
+++ b/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/FloatFormatter.java
@@ -24,7 +24,7 @@ package uk.ac.ebi.gxa.utils;
 
 import static java.lang.Math.*;
 
-public abstract class FloatFormatter {
+public final class FloatFormatter {
     private FloatFormatter() {
     }
 

--- a/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/FloatFormatter.java
+++ b/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/FloatFormatter.java
@@ -49,6 +49,9 @@ public abstract class FloatFormatter {
     }
 
     private static double trimSignificantDigits(double value, int significantDigits) {
+        if (abs(value) < pow(10.0, -significantDigits))
+            return 0;
+
         int order = (int) ceil(log10(abs(value)));
         final double precision = pow(10.0, order - significantDigits);
         return round(value / precision) * precision;

--- a/atlas-utils/src/test/java/uk/ac/ebi/gxa/utils/FloatFormatterTest.java
+++ b/atlas-utils/src/test/java/uk/ac/ebi/gxa/utils/FloatFormatterTest.java
@@ -13,6 +13,7 @@ public class FloatFormatterTest {
         assertEquals("5.0", FloatFormatter.formatDouble(5, 1));
         assertEquals("600.0", FloatFormatter.formatDouble(555, 1));
         assertEquals("6.0E10", FloatFormatter.formatDouble(55555555555.0, 1));
+        assertEquals("5.56E10", FloatFormatter.formatDouble(55555555555.0, 3));
     }
 
     @Test
@@ -23,5 +24,6 @@ public class FloatFormatterTest {
         assertEquals("5.0", FloatFormatter.formatFloat(5, 1));
         assertEquals("600.0", FloatFormatter.formatFloat(555, 1));
         assertEquals("6.0E10", FloatFormatter.formatFloat(55555555555.0F, 1));
+        assertEquals("5.56E10", FloatFormatter.formatFloat(55555555555.0F, 3));
     }
 }

--- a/atlas-utils/src/test/java/uk/ac/ebi/gxa/utils/FloatFormatterTest.java
+++ b/atlas-utils/src/test/java/uk/ac/ebi/gxa/utils/FloatFormatterTest.java
@@ -1,0 +1,27 @@
+package uk.ac.ebi.gxa.utils;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class FloatFormatterTest {
+    @Test
+    public void testDoubleFormats() {
+        assertEquals("null", FloatFormatter.formatDouble(Double.POSITIVE_INFINITY, 1));
+        assertEquals("null", FloatFormatter.formatDouble(Double.NaN, 1));
+        assertEquals("0.0", FloatFormatter.formatDouble(0, 1));
+        assertEquals("5.0", FloatFormatter.formatDouble(5, 1));
+        assertEquals("600.0", FloatFormatter.formatDouble(555, 1));
+        assertEquals("6.0E10", FloatFormatter.formatDouble(55555555555.0, 1));
+    }
+
+    @Test
+    public void testFloatFormats() {
+        assertEquals("null", FloatFormatter.formatFloat(Float.POSITIVE_INFINITY, 1));
+        assertEquals("null", FloatFormatter.formatFloat(Float.NaN, 1));
+        assertEquals("0.0", FloatFormatter.formatFloat(0, 1));
+        assertEquals("5.0", FloatFormatter.formatFloat(5, 1));
+        assertEquals("600.0", FloatFormatter.formatFloat(555, 1));
+        assertEquals("6.0E10", FloatFormatter.formatFloat(55555555555.0F, 1));
+    }
+}

--- a/atlas-web/src/test/java/uk/ac/ebi/gxa/requesthandlers/base/restutil/JsonResultRendererTest.java
+++ b/atlas-web/src/test/java/uk/ac/ebi/gxa/requesthandlers/base/restutil/JsonResultRendererTest.java
@@ -94,7 +94,7 @@ public class JsonResultRendererTest {
         r.render(o, sb, Object.class);
         Assert.assertEquals("Wrong format!", "atlas({\n" +
                 "    \"int\" : 123,\n" +
-                "    \"double\" : 1.23464E15,\n" +
+                "    \"double\" : 1.2346E15,\n" +
                 "    \"array\" : [1, 2, 3, 4],\n" +
                 "    \"mapas\" : {\n" +
                 "        \"e\" : [\n" +

--- a/atlas-web/src/test/java/uk/ac/ebi/gxa/requesthandlers/base/restutil/JsonResultRendererTest.java
+++ b/atlas-web/src/test/java/uk/ac/ebi/gxa/requesthandlers/base/restutil/JsonResultRendererTest.java
@@ -86,7 +86,7 @@ public class JsonResultRendererTest {
 
             @RestOut
             public int[] getArray() {
-                return new int[] {1, 2, 3, 4};
+                return new int[]{1, 2, 3, 4};
             }
         };
 


### PR DESCRIPTION
A fix for `JsonResultRendererTest : No indent render (testNoIndentRender)`

@olgamelnichuk, could you please review as all others are busy? 
