### PR TITLE
Atlas 2.0.8 fixes: EBI menu fix

### DIFF
--- a/atlas-analytics/pom.xml
+++ b/atlas-analytics/pom.xml
@@ -26,11 +26,11 @@
     <parent>
         <artifactId>atlas</artifactId>
         <groupId>uk.ac.ebi.gxa</groupId>
-        <version>2.0.8</version>
+        <version>2.0.8.1-SNAPSHOT</version>
     </parent>
     <groupId>uk.ac.ebi.gxa</groupId>
     <artifactId>atlas-analytics</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.8.1-SNAPSHOT</version>
     <name>Gene Expression Atlas Analytics</name>
     <url>http://www.ebi.ac.uk/gxa/</url>
     <dependencies>
@@ -38,18 +38,18 @@
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-dao</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-utils</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <!-- NetCDF reading library -->
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>netcdf-reader</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <!-- database connection pooling from apache -->
         <dependency>
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-dao</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/atlas-dao/pom.xml
+++ b/atlas-dao/pom.xml
@@ -26,11 +26,11 @@
     <parent>
         <groupId>uk.ac.ebi.gxa</groupId>
         <artifactId>atlas</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.8.1-SNAPSHOT</version>
     </parent>
     <groupId>uk.ac.ebi.gxa</groupId>
     <artifactId>atlas-dao</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.8.1-SNAPSHOT</version>
     <name>Gene Expression Atlas Database Access Layer</name>
     <url>http://www.ebi.ac.uk/gxa/</url>
 
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-model</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <!-- oracle JDBC drivers for specific oracle stored procedures -->
         <dependency>

--- a/atlas-index-api/pom.xml
+++ b/atlas-index-api/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.ac.ebi.gxa</groupId>
     <artifactId>atlas-index-api</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.8.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Gene Expression Atlas Index Common API</name>
     <url>http://www.ebi.ac.uk/gxa/</url>
@@ -32,7 +32,7 @@
     <parent>
         <groupId>uk.ac.ebi.gxa</groupId>
         <artifactId>atlas</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.8.1-SNAPSHOT</version>
     </parent>
 
     <repositories>
@@ -60,12 +60,12 @@
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-model</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-utils</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency> <!-- log4j binding: all logging captured via slf4j sinks to log4j -->
             <groupId>org.slf4j</groupId>

--- a/atlas-loader/pom.xml
+++ b/atlas-loader/pom.xml
@@ -26,11 +26,11 @@
     <parent>
         <groupId>uk.ac.ebi.gxa</groupId>
         <artifactId>atlas</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.8.1-SNAPSHOT</version>
     </parent>
     <groupId>uk.ac.ebi.gxa</groupId>
     <artifactId>atlas-loader</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.8.1-SNAPSHOT</version>
     <name>Gene Expression Atlas Data Loader</name>
     <url>http://www.ebi.ac.uk/gxa/</url>
 
@@ -59,25 +59,25 @@
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-analytics</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
 
         <!-- loader API and db utils -->
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-dao</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>netcdf-reader</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <!-- test scope dependency on ae2-dao tests -->
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-dao</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/atlas-model/pom.xml
+++ b/atlas-model/pom.xml
@@ -26,18 +26,18 @@
     <parent>
         <groupId>uk.ac.ebi.gxa</groupId>
         <artifactId>atlas</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.8.1-SNAPSHOT</version>
     </parent>
     <groupId>uk.ac.ebi.gxa</groupId>
     <artifactId>atlas-model</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.8.1-SNAPSHOT</version>
     <name>Gene Expression Atlas Database Object Model</name>
     <url>http://www.ebi.ac.uk/gxa/</url>
     <dependencies>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-utils</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/atlas-test/pom.xml
+++ b/atlas-test/pom.xml
@@ -26,11 +26,11 @@
     <parent>
         <artifactId>atlas</artifactId>
         <groupId>uk.ac.ebi.gxa</groupId>
-        <version>2.0.8</version>
+        <version>2.0.8.1-SNAPSHOT</version>
     </parent>
     <groupId>uk.ac.ebi.gxa</groupId>
     <artifactId>atlas-test</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.8.1-SNAPSHOT</version>
     <name>Gene Expression Atlas Test Applications</name>
     <url>http://maven.apache.org</url>
 
@@ -63,17 +63,17 @@
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-loader</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>indexbuilder</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-analytics</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-dbcp</groupId>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-dao</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
             <type>test-jar</type>            
             <scope>test</scope>
         </dependency>        

--- a/atlas-utils/pom.xml
+++ b/atlas-utils/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>uk.ac.ebi.gxa</groupId>
         <artifactId>atlas</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.8.1-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -82,7 +82,7 @@
     </dependencies>
     <groupId>uk.ac.ebi.gxa</groupId>
     <artifactId>atlas-utils</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.8.1-SNAPSHOT</version>
     <name>Gene Expression Atlas Java Utility Classes</name>
     <url>http://www.ebi.ac.uk/gxa/</url>
 </project>

--- a/atlas-web/pom.xml
+++ b/atlas-web/pom.xml
@@ -25,12 +25,12 @@
     <parent>
         <groupId>uk.ac.ebi.gxa</groupId>
         <artifactId>atlas</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.8.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.ac.ebi.gxa</groupId>
     <artifactId>atlas-web</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.8.1-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Gene Expression Atlas WebApp</name>
     <url>http://www.ebi.ac.uk/gxa</url>
@@ -134,17 +134,17 @@
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-utils</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-index-api</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-dao</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -164,22 +164,22 @@
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>indexbuilder</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>netcdf-reader</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-analytics</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-loader</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
 
         <!-- spring webmvc for admin servlet -->
@@ -290,13 +290,13 @@
             <artifactId>atlas-index-api</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-test</artifactId>
             <scope>test</scope>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <!-- also need dbunit jars, transitive deps don't work on tests? -->
         <dependency>
@@ -316,14 +316,14 @@
             <artifactId>atlas-dao</artifactId>
             <scope>test</scope>
             <type>test-jar</type>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-test</artifactId>
             <scope>test</scope>
             <type>test-jar</type>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.oracle</groupId>

--- a/atlas-web/src/main/webapp/atlas-ebi.css
+++ b/atlas-web/src/main/webapp/atlas-ebi.css
@@ -8,7 +8,7 @@
 */
 .contents {
     position: relative !important;
-    padding-top: 57px !important;
+    margin-top: 57px !important;
     top: 0 !important;
 }
 

--- a/indexbuilder/pom.xml
+++ b/indexbuilder/pom.xml
@@ -25,11 +25,11 @@
     <parent>
         <groupId>uk.ac.ebi.gxa</groupId>
         <artifactId>atlas</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.8.1-SNAPSHOT</version>
     </parent>
     <groupId>uk.ac.ebi.gxa</groupId>
     <artifactId>indexbuilder</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.8.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Gene Expression Atlas Indexbuilder</name>
     <url>http://www.ebi.ac.uk/gxa/</url>
@@ -40,24 +40,24 @@
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-dao</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-utils</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-index-api</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>netcdf-reader</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-dao</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/netcdf-reader/pom.xml
+++ b/netcdf-reader/pom.xml
@@ -26,18 +26,18 @@
     <parent>
         <artifactId>atlas</artifactId>
         <groupId>uk.ac.ebi.gxa</groupId>
-        <version>2.0.8</version>
+        <version>2.0.8.1-SNAPSHOT</version>
     </parent>
     <groupId>uk.ac.ebi.gxa</groupId>
     <artifactId>netcdf-reader</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.8.1-SNAPSHOT</version>
     <name>Gene Expression Atlas NetCDF Reader Utility</name>
     <url>http://maven.apache.org</url>
     <dependencies>
         <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-model</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.8.1-SNAPSHOT</version>
         </dependency>
 
         <!-- NetCDF library -->

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>uk.ac.ebi.gxa</groupId>
     <artifactId>atlas</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.8</version>
+    <version>2.0.8.1-SNAPSHOT</version>
     <name>Gene Expression Atlas</name>
     <url>http://www.ebi.ac.uk/gxa/</url>
 

--- a/sql/create_sql_for_table.sql
+++ b/sql/create_sql_for_table.sql
@@ -12,7 +12,7 @@ set verify off
 SELECT 'SELECT ' || WM_CONCAT(
   DECODE(data_type, 'DATE', 'TO_CHAR(' || column_name || ',''YYYY-MM-DD HH24:MI:SS'')',
          DECODE(data_type, 'VARCHAR2',
-                  ' DECODE(' || column_name || ', null, ' || column_name || ', REPLACE(REPLACE(' || column_name ||', chr(10), chr(32)),''  '',chr(32)))', column_name)))
+                  ' DECODE(' || column_name || ', null, ' || column_name || ', REPLACE(' || column_name ||', chr(10), chr(32)))', column_name)))
  || ' FROM ' || UPPER('A2_&1')
 FROM user_tab_columns WHERE table_name=UPPER('A2_&1');
 exit;


### PR DESCRIPTION
@alf239, @rpetry, please review this fix. I completely forgot about creating the trac issue, so I added all details below.

Here is the bug report from EBI external services:

There is a problem with http://www.ebi.ac.uk/gxa in Firefox and Chrome (Explorer fine) - I cannot access any links in the EBI header.
I think this is due to the positioning/padding given in atlas-ebi.css
.contents {
  position: relative !important;
  padding-top: 57px !important;
  top: 0 !important;
}
If you switch the 57 and 0, or use margin-top instead of padding-top the links become clickable, however not sure if this causes other problems elsewhere.
