### PR TITLE
stats.jsp

### DIFF
--- a/atlas-web/src/main/webapp/stats.jsp
+++ b/atlas-web/src/main/webapp/stats.jsp
@@ -1,0 +1,5 @@
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ page buffer="0kb" %>
+<%@ page contentType="text/plain;charset=UTF-8" language="java" %>
+<jsp:useBean id="atlasStatistics" class="uk.ac.ebi.microarray.atlas.model.AtlasStatistics" scope="application"/>
+Atlas Data Release <c:out value="${atlasStatistics.dataRelease}"/>: <c:out value="${atlasStatistics.experimentCount}"/> experiments, <c:out value="${atlasStatistics.assayCount}"/> assays, <c:out value="${atlasStatistics.factorValueCount}"/> conditions

--- a/atlas-web/src/main/webapp/stats.jsp
+++ b/atlas-web/src/main/webapp/stats.jsp
@@ -1,3 +1,6 @@
+<%--
+This file is used by ArrayExpress interface to render short summary of Atlas DB
+--%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ page buffer="0kb" %>
 <%@ page contentType="text/plain;charset=UTF-8" language="java" %>


### PR DESCRIPTION
Reverted stats.jsp from rev. 5a401819ee89097461ab2928f5ce351614a3b305 (accidentally dropped in c59812709cb6d25cffad8323fafe95372fba8644 as not used)

The JSP in question is used by @kolais for ArrayExpress UI. We can discuss its removal, but so far it would be nice to keep this functionality around.
