### PR TITLE
Cascading fixed for AssayProperty and SampleProperty

### DIFF
--- a/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/hibernate/SchemaValidatingAnnotationSessionFactoryBean.java
+++ b/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/hibernate/SchemaValidatingAnnotationSessionFactoryBean.java
@@ -21,7 +21,7 @@ public class SchemaValidatingAnnotationSessionFactoryBean extends AnnotationSess
         logger.info("Validating database schema for Hibernate SessionFactory");
         HibernateTemplate hibernateTemplate = new HibernateTemplate(
                 getSessionFactory());
-        hibernateTemplate.setFlushMode(HibernateTemplate.FLUSH_NEVER);
+        hibernateTemplate.setFlushMode(HibernateTemplate.FLUSH_AUTO);
         hibernateTemplate.execute(new HibernateCallback<Object>() {
             public Object doInHibernate(Session session)
                     throws HibernateException, SQLException {

--- a/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/hibernate/SchemaValidatingAnnotationSessionFactoryBean.java
+++ b/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/hibernate/SchemaValidatingAnnotationSessionFactoryBean.java
@@ -19,9 +19,7 @@ import java.sql.SQLException;
 public class SchemaValidatingAnnotationSessionFactoryBean extends AnnotationSessionFactoryBean {
     public void validateDatabaseSchema() throws DataAccessException {
         logger.info("Validating database schema for Hibernate SessionFactory");
-        HibernateTemplate hibernateTemplate = new HibernateTemplate(
-                getSessionFactory());
-        hibernateTemplate.setFlushMode(HibernateTemplate.FLUSH_AUTO);
+        HibernateTemplate hibernateTemplate = new HibernateTemplate(getSessionFactory());
         hibernateTemplate.execute(new HibernateCallback<Object>() {
             public Object doInHibernate(Session session)
                     throws HibernateException, SQLException {

--- a/atlas-dao/src/main/resources/uk/ac/ebi/gxa/dao/daoContext.xml
+++ b/atlas-dao/src/main/resources/uk/ac/ebi/gxa/dao/daoContext.xml
@@ -26,17 +26,17 @@
         </property>
     </bean>
 
+    <bean id="atlasTxManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+        <property name="dataSource" ref="atlasDataSource"/>
+    </bean>
+
     <bean name="atlasJdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
         <!-- datasource bean, from JNDI -->
         <property name="dataSource" ref="atlasDataSource"/>
         <property name="nativeJdbcExtractor" ref="nativeJdbcExtractor"/>
     </bean>
 
-    <bean id="txManager" class="org.springframework.orm.hibernate3.HibernateTransactionManager">
-        <property name="sessionFactory" ref="sessionFactory"/>
-    </bean>
-
-    <tx:annotation-driven transaction-manager="txManager"/>
+    <tx:annotation-driven transaction-manager="atlasTxManager"/>
 
     <context:component-scan base-package="uk.ac.ebi.gxa.dao"/>
     <context:annotation-config/>

--- a/atlas-dao/src/main/resources/uk/ac/ebi/gxa/dao/daoContext.xml
+++ b/atlas-dao/src/main/resources/uk/ac/ebi/gxa/dao/daoContext.xml
@@ -7,6 +7,25 @@
             http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
             http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
+    <bean id="hibernateClasses" class="org.springframework.beans.factory.config.ListFactoryBean">
+        <property name="sourceList">
+            <list>
+                <value>uk.ac.ebi.microarray.atlas.model.ArrayDesign</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Assay</value>
+                <value>uk.ac.ebi.microarray.atlas.model.AssayProperty</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Asset</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Experiment</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Ontology</value>
+                <value>uk.ac.ebi.microarray.atlas.model.OntologyTerm</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Organism</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Property</value>
+                <value>uk.ac.ebi.microarray.atlas.model.PropertyValue</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Sample</value>
+                <value>uk.ac.ebi.microarray.atlas.model.SampleProperty</value>
+            </list>
+        </property>
+    </bean>
+
     <bean name="atlasJdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
         <!-- datasource bean, from JNDI -->
         <property name="dataSource" ref="atlasDataSource"/>

--- a/atlas-dao/src/main/resources/uk/ac/ebi/gxa/dao/daoContext.xml
+++ b/atlas-dao/src/main/resources/uk/ac/ebi/gxa/dao/daoContext.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+            http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean name="atlasJdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
         <!-- datasource bean, from JNDI -->
@@ -9,41 +13,14 @@
         <property name="nativeJdbcExtractor" ref="nativeJdbcExtractor"/>
     </bean>
 
-    <bean id="sessionFactory" class="uk.ac.ebi.gxa.dao.hibernate.SchemaValidatingAnnotationSessionFactoryBean">
-        <property name="dataSource" ref="atlasDataSource"/>
-        <property name="annotatedClasses">
-            <list>
-                <value>uk.ac.ebi.microarray.atlas.model.ArrayDesign</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Assay</value>
-                <value>uk.ac.ebi.microarray.atlas.model.AssayProperty</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Asset</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Experiment</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Ontology</value>
-                <value>uk.ac.ebi.microarray.atlas.model.OntologyTerm</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Organism</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Property</value>
-                <value>uk.ac.ebi.microarray.atlas.model.PropertyValue</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Sample</value>
-                <value>uk.ac.ebi.microarray.atlas.model.SampleProperty</value>
-            </list>
-        </property>
-
-        <property name="namingStrategy" ref="hibernateNamingStrategy"/>
-        <property name="schemaUpdate" value="false"/>
-        <property name="hibernateProperties">
-            <props>
-                <prop key="hibernate.dialect">org.hibernate.dialect.Oracle10gDialect</prop>
-                <prop key="hibernate.query.substitutions">true 1,false 0</prop>
-                <prop key="hibernate.cache.use_query_cache">true</prop>
-                <prop key="hibernate.cache.use_second_level_cache">true</prop>
-                <prop key="hibernate.cache.use_structured_entries">true</prop>
-                <prop key="hibernate.cache.region.factory_class">
-                    net.sf.ehcache.hibernate.SingletonEhCacheRegionFactory
-                </prop>
-                <prop key="hibernate.show_sql">false</prop>
-            </props>
-        </property>
+    <bean id="txManager" class="org.springframework.orm.hibernate3.HibernateTransactionManager">
+        <property name="sessionFactory" ref="sessionFactory"/>
     </bean>
+
+    <tx:annotation-driven transaction-manager="txManager"/>
+
+    <context:component-scan base-package="uk.ac.ebi.gxa.dao"/>
+    <context:annotation-config/>
 
     <bean name="hibernateNamingStrategy" class="uk.ac.ebi.gxa.dao.hibernate.AtlasNamingStrategy"/>
 
@@ -90,4 +67,9 @@
     <bean name="softwareDAO" class="uk.ac.ebi.gxa.dao.SoftwareDAO">
         <constructor-arg ref="atlasJdbcTemplate"/>
     </bean>
+
+    <!-- Common spring-drive data access configuration -->
+    <!-- native extractor for fetching oracle connections from pool wrapper etc -->
+    <bean name="nativeJdbcExtractor"
+          class="org.springframework.jdbc.support.nativejdbc.CommonsDbcpNativeJdbcExtractor"/>
 </beans>

--- a/atlas-dao/src/main/resources/uk/ac/ebi/gxa/dao/hibernateContext.xml
+++ b/atlas-dao/src/main/resources/uk/ac/ebi/gxa/dao/hibernateContext.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="sessionFactory" class="uk.ac.ebi.gxa.dao.hibernate.SchemaValidatingAnnotationSessionFactoryBean">
+        <property name="dataSource" ref="atlasDataSource"/>
+        <property name="annotatedClasses">
+            <list>
+                <value>uk.ac.ebi.microarray.atlas.model.ArrayDesign</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Assay</value>
+                <value>uk.ac.ebi.microarray.atlas.model.AssayProperty</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Asset</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Experiment</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Ontology</value>
+                <value>uk.ac.ebi.microarray.atlas.model.OntologyTerm</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Organism</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Property</value>
+                <value>uk.ac.ebi.microarray.atlas.model.PropertyValue</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Sample</value>
+                <value>uk.ac.ebi.microarray.atlas.model.SampleProperty</value>
+            </list>
+        </property>
+
+        <property name="namingStrategy" ref="hibernateNamingStrategy"/>
+        <property name="schemaUpdate" value="false"/>
+        <property name="hibernateProperties">
+            <props>
+                <prop key="hibernate.dialect">org.hibernate.dialect.Oracle10gDialect</prop>
+                <prop key="hibernate.query.substitutions">true 1,false 0</prop>
+                <prop key="hibernate.cache.use_query_cache">true</prop>
+                <prop key="hibernate.cache.use_second_level_cache">true</prop>
+                <prop key="hibernate.cache.use_structured_entries">true</prop>
+                <prop key="hibernate.cache.region.factory_class">
+                    net.sf.ehcache.hibernate.SingletonEhCacheRegionFactory
+                </prop>
+                <prop key="hibernate.show_sql">false</prop>
+            </props>
+        </property>
+    </bean>
+</beans>

--- a/atlas-dao/src/main/resources/uk/ac/ebi/gxa/dao/hibernateContext.xml
+++ b/atlas-dao/src/main/resources/uk/ac/ebi/gxa/dao/hibernateContext.xml
@@ -5,23 +5,7 @@
 
     <bean id="sessionFactory" class="uk.ac.ebi.gxa.dao.hibernate.SchemaValidatingAnnotationSessionFactoryBean">
         <property name="dataSource" ref="atlasDataSource"/>
-        <property name="annotatedClasses">
-            <list>
-                <value>uk.ac.ebi.microarray.atlas.model.ArrayDesign</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Assay</value>
-                <value>uk.ac.ebi.microarray.atlas.model.AssayProperty</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Asset</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Experiment</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Ontology</value>
-                <value>uk.ac.ebi.microarray.atlas.model.OntologyTerm</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Organism</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Property</value>
-                <value>uk.ac.ebi.microarray.atlas.model.PropertyValue</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Sample</value>
-                <value>uk.ac.ebi.microarray.atlas.model.SampleProperty</value>
-            </list>
-        </property>
-
+        <property name="annotatedClasses" ref="hibernateClasses" />
         <property name="namingStrategy" ref="hibernateNamingStrategy"/>
         <property name="schemaUpdate" value="false"/>
         <property name="hibernateProperties">

--- a/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/AtlasDAOTestCase.java
+++ b/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/AtlasDAOTestCase.java
@@ -155,7 +155,7 @@ public abstract class AtlasDAOTestCase extends DBTestCase {
     }
 
     @BeforeClass
-    private void createDatabase() throws SQLException, ClassNotFoundException {
+    public static void createDatabase() throws SQLException, ClassNotFoundException {
         // Load the HSQL Database Engine JDBC driver
         Class.forName("org.hsqldb.jdbcDriver");
 
@@ -594,9 +594,8 @@ public abstract class AtlasDAOTestCase extends DBTestCase {
     }
 
 
-    @SuppressWarnings("unused")
     @AfterClass
-    private void destroyDatabase() throws SQLException, ClassNotFoundException {
+    public static void destroyDatabase() throws SQLException, ClassNotFoundException {
         // Load the HSQL Database Engine JDBC driver
         Class.forName("org.hsqldb.jdbcDriver");
 
@@ -607,7 +606,7 @@ public abstract class AtlasDAOTestCase extends DBTestCase {
         conn.close();
     }
 
-    private void runStatement(Connection conn, String sql) throws SQLException {
+    private static void runStatement(Connection conn, String sql) throws SQLException {
         // just using raw sql here, prior to any dao/jdbctemplate setup
         Statement st = conn.createStatement();
         st.execute(sql);

--- a/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/AtlasDAOTestCase.java
+++ b/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/AtlasDAOTestCase.java
@@ -47,7 +47,7 @@ import java.sql.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
-@TransactionConfiguration(transactionManager = "txManager", defaultRollback = false)
+@TransactionConfiguration(transactionManager = "atlasTxManager", defaultRollback = false)
 @Transactional
 public abstract class AtlasDAOTestCase extends DataSourceBasedDBTestCase {
     private static final String ATLAS_DATA_RESOURCE = "atlas-be-db.xml";

--- a/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/TestAtlasDAO.java
+++ b/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/TestAtlasDAO.java
@@ -65,10 +65,6 @@ public class TestAtlasDAO extends AtlasDAOTestCase {
 
         // test data contains 2 experiments, check size of returned list
         assertEquals("Wrong number of experiments", expected, actual);
-
-        System.out.println(
-                "Expected number of experiments: " + expected + ", actual: " +
-                        actual);
     }
 
     @Test
@@ -84,10 +80,6 @@ public class TestAtlasDAO extends AtlasDAOTestCase {
         assertNotNull(exp);
         assertEquals("Accessions don't match", exp.getAccession(), accession);
         assertEquals("IDs don't match", exp.getId(), Long.valueOf(id));
-
-        System.out.println(
-                "Fetched expected experiment id: " + id + " by accession: " +
-                        accession + " successfully");
     }
 
     private long someExperimentId() throws Exception {
@@ -111,11 +103,6 @@ public class TestAtlasDAO extends AtlasDAOTestCase {
             assertNotNull(assay);
             assertEquals("Accessions don't match", assay.getExperiment().getAccession(),
                     accession);
-
-            System.out.println(
-                    "Fetched expected assay id: " + assay.getAssayID() +
-                            " by accession: " +
-                            accession + " successfully");
         }
     }
 
@@ -126,10 +113,6 @@ public class TestAtlasDAO extends AtlasDAOTestCase {
         int actual = arrayDesignDAO.getAllArrayDesigns().size();
 
         assertEquals("Wrong number of array designs", expected, actual);
-
-        System.out.println(
-                "Expected number of array designs: " + expected + ", actual: " +
-                        actual);
     }
 
     @Test
@@ -150,10 +133,6 @@ public class TestAtlasDAO extends AtlasDAOTestCase {
         assertEquals("Accessions don't match", arrayDesign.getAccession(),
                 accession);
         assertEquals("IDs don't match", arrayDesign.getArrayDesignID(), id);
-
-        System.out.println(
-                "Fetched expected array design id: " + id + " by accession: " +
-                        accession + " successfully");
     }
 
 

--- a/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/TestAtlasDAO.java
+++ b/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/TestAtlasDAO.java
@@ -43,6 +43,9 @@ import java.util.List;
 @Transactional
 public class TestAtlasDAO extends AtlasDAOTestCase {
 
+    private static final String ABC_ABCXYZ_SOME_THING_1234_ABC123 = "abc:ABCxyz:SomeThing:1234.ABC123";
+    private static final String E_MEXP_420 = "E-MEXP-420";
+
     @Override
     @Before
     public void setUp() throws Exception {
@@ -154,8 +157,8 @@ public class TestAtlasDAO extends AtlasDAOTestCase {
 
         removeAssayProperties();
 
-        final Experiment experiment = experimentDAO.getExperimentByAccession("E-MEXP-420");
-        final Assay assay = experiment.getAssay("abc:ABCxyz:SomeThing:1234.ABC123");
+        final Experiment experiment = experimentDAO.getExperimentByAccession(E_MEXP_420);
+        final Assay assay = experiment.getAssay(ABC_ABCXYZ_SOME_THING_1234_ABC123);
 
         assertEquals("Properties are not deleted!", 0, assay.getProperties().size());
         assertEquals("Deleted the OntologyTerm - invalid cascading", termsCount,
@@ -170,8 +173,8 @@ public class TestAtlasDAO extends AtlasDAOTestCase {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     private void removeAssayProperties() {
-        final Experiment experiment = experimentDAO.getExperimentByAccession("E-MEXP-420");
-        final Assay assay = experiment.getAssay("abc:ABCxyz:SomeThing:1234.ABC123");
+        final Experiment experiment = experimentDAO.getExperimentByAccession(E_MEXP_420);
+        final Assay assay = experiment.getAssay(ABC_ABCXYZ_SOME_THING_1234_ABC123);
         assay.getProperties().clear();
         experimentDAO.save(experiment);
     }

--- a/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/TestBioentityDAO.java
+++ b/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/TestBioentityDAO.java
@@ -1,23 +1,13 @@
 package uk.ac.ebi.gxa.dao;
 
-import org.dbunit.dataset.IDataSet;
-import org.dbunit.dataset.xml.FlatXmlDataSetBuilder;
+import org.junit.Test;
 import uk.ac.ebi.microarray.atlas.model.BEPropertyValue;
 import uk.ac.ebi.microarray.atlas.model.BioEntity;
 
-import java.io.InputStream;
 import java.util.List;
 
 public class TestBioentityDAO extends AtlasDAOTestCase {
-
-    private static final String ATLAS_BE_DATA_RESOURCE = "atlas-be-db.xml";
-
-    protected IDataSet getDataSet() throws Exception {
-        InputStream in = this.getClass().getClassLoader().getResourceAsStream(ATLAS_BE_DATA_RESOURCE);
-
-        return new FlatXmlDataSetBuilder().build(in);
-    }
-
+    @Test
     public void testGetAllGenes() throws Exception {
         int expected = 1;
 
@@ -28,6 +18,7 @@ public class TestBioentityDAO extends AtlasDAOTestCase {
         assertEquals("Wrong number of genes", expected, actual);
     }
 
+    @Test
     public void testGetPropertiesForGenes() throws Exception {
         List<BioEntity> bioEntities = bioEntityDAO.getAllGenesFast();
 

--- a/atlas-dao/src/test/resources/atlas-be-db.xml
+++ b/atlas-dao/src/test/resources/atlas-be-db.xml
@@ -192,16 +192,6 @@
             SOFTWAREID='1'
             />
 
-    <!--<A2_BE2BE_UNFOLDED-->
-    <!--BEIDFROM="1"-->
-    <!--BEIDTO="2"-->
-    <!--/>-->
-
-    <!--<A2_BE2BE_UNFOLDED-->
-    <!--BEIDFROM="2"-->
-    <!--BEIDTO="1"-->
-    <!--/>-->
-
     <A2_GENEPROPERTY
             genepropertyid="1"
             name="goterm"
@@ -504,4 +494,21 @@
             organismid="1"
             />
 
+    <A2_ONTOLOGY
+            ONTOLOGYID="1"
+            name="EFO"
+            SOURCE_URI="/dev/null"
+            version="unknown-alpha"
+            DESCRIPTION="Sample experimental factor ontology"/>
+
+    <A2_ONTOLOGYTERM
+            ONTOLOGYTERMID="1"
+            ONTOLOGYID="1"
+            ACCESSION="EFO_0000827"
+            DESCRIPTION="Just a term"/>
+
+    <A2_ASSAYPVONTOLOGY
+            ASSAYPVONTOLOGYID="1"
+            ONTOLOGYTERMID="1"
+            ASSAYPVID="1"/>
 </dataset>

--- a/atlas-dao/src/test/resources/uk/ac/ebi/gxa/dao/AtlasDAOTestCase-context.xml
+++ b/atlas-dao/src/test/resources/uk/ac/ebi/gxa/dao/AtlasDAOTestCase-context.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <import resource="classpath*:uk/ac/ebi/gxa/dao/daoContext.xml"/>
+    <import resource="classpath*:uk/ac/ebi/gxa/dao/testHibernateContext.xml"/>
+
+    <bean name="test" class="uk.ac.ebi.gxa.dao.TestAtlasDAO" />
+</beans>

--- a/atlas-dao/src/test/resources/uk/ac/ebi/gxa/dao/testHibernateContext.xml
+++ b/atlas-dao/src/test/resources/uk/ac/ebi/gxa/dao/testHibernateContext.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="atlasDataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+        <property name="driverClass" value="org.hsqldb.jdbcDriver"/>
+        <property name="url" value="jdbc:hsqldb:mem:atlas"/>
+        <property name="username" value="sa"/>
+        <property name="password" value=""/>
+    </bean>
+
+    <bean id="sessionFactory" class="uk.ac.ebi.gxa.dao.hibernate.SchemaValidatingAnnotationSessionFactoryBean">
+        <property name="dataSource" ref="atlasDataSource"/>
+        <property name="annotatedClasses">
+            <list>
+                <value>uk.ac.ebi.microarray.atlas.model.ArrayDesign</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Assay</value>
+                <value>uk.ac.ebi.microarray.atlas.model.AssayProperty</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Asset</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Experiment</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Ontology</value>
+                <value>uk.ac.ebi.microarray.atlas.model.OntologyTerm</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Organism</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Property</value>
+                <value>uk.ac.ebi.microarray.atlas.model.PropertyValue</value>
+                <value>uk.ac.ebi.microarray.atlas.model.Sample</value>
+                <value>uk.ac.ebi.microarray.atlas.model.SampleProperty</value>
+            </list>
+        </property>
+
+        <property name="namingStrategy" ref="hibernateNamingStrategy"/>
+        <property name="schemaUpdate" value="false"/>
+        <property name="hibernateProperties">
+            <props>
+                <prop key="hibernate.dialect">org.hibernate.dialect.HSQLDialect</prop>
+                <prop key="hibernate.query.substitutions">true 1,false 0</prop>
+                <prop key="hibernate.cache.use_query_cache">false</prop>
+                <prop key="hibernate.cache.use_second_level_cache">false</prop>
+                <prop key="hibernate.cache.use_structured_entries">false</prop>
+                <prop key="hibernate.show_sql">false</prop>
+            </props>
+        </property>
+    </bean>
+</beans>

--- a/atlas-dao/src/test/resources/uk/ac/ebi/gxa/dao/testHibernateContext.xml
+++ b/atlas-dao/src/test/resources/uk/ac/ebi/gxa/dao/testHibernateContext.xml
@@ -12,23 +12,7 @@
 
     <bean id="sessionFactory" class="uk.ac.ebi.gxa.dao.hibernate.SchemaValidatingAnnotationSessionFactoryBean">
         <property name="dataSource" ref="atlasDataSource"/>
-        <property name="annotatedClasses">
-            <list>
-                <value>uk.ac.ebi.microarray.atlas.model.ArrayDesign</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Assay</value>
-                <value>uk.ac.ebi.microarray.atlas.model.AssayProperty</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Asset</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Experiment</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Ontology</value>
-                <value>uk.ac.ebi.microarray.atlas.model.OntologyTerm</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Organism</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Property</value>
-                <value>uk.ac.ebi.microarray.atlas.model.PropertyValue</value>
-                <value>uk.ac.ebi.microarray.atlas.model.Sample</value>
-                <value>uk.ac.ebi.microarray.atlas.model.SampleProperty</value>
-            </list>
-        </property>
-
+        <property name="annotatedClasses" ref="hibernateClasses"/>
         <property name="namingStrategy" ref="hibernateNamingStrategy"/>
         <property name="schemaUpdate" value="false"/>
         <property name="hibernateProperties">

--- a/atlas-loader/src/test/java/uk/ac/ebi/gxa/loader/TestAtlasMAGETABLoader.java
+++ b/atlas-loader/src/test/java/uk/ac/ebi/gxa/loader/TestAtlasMAGETABLoader.java
@@ -24,6 +24,7 @@ package uk.ac.ebi.gxa.loader;
 
 import com.google.common.collect.HashMultimap;
 import org.easymock.EasyMock;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.ebi.arrayexpress2.magetab.datamodel.MAGETABInvestigation;
@@ -61,11 +62,12 @@ public class TestAtlasMAGETABLoader extends AtlasDAOTestCase {
                 "E-GEOD-3790.idf.txt");
     }
 
-    protected void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
         cache = null;
     }
 
+    @Test
     public void testParseAndCheckExperiments() throws AtlasLoaderException {
         log.debug("Running parse and check experiment test...");
         HandlerPool pool = HandlerPool.getInstance();
@@ -82,6 +84,7 @@ public class TestAtlasMAGETABLoader extends AtlasDAOTestCase {
         log.debug("Experiment parse and check test done!");
     }
 
+    @Test
     public void testAll() throws Exception {
         log.debug("Running parse and check experiment test...");
         HandlerPool pool = HandlerPool.getInstance();
@@ -121,6 +124,7 @@ public class TestAtlasMAGETABLoader extends AtlasDAOTestCase {
         return computeService;
     }
 
+    @Test
     public void testParseAndCheckSamplesAndAssays() throws AtlasLoaderException {
         log.debug("Running parse and check samples and assays test...");
         HandlerPool pool = HandlerPool.getInstance();

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/AssayProperty.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/AssayProperty.java
@@ -48,7 +48,7 @@ public final class AssayProperty {
     @ManyToOne
     @Fetch(FetchMode.SELECT)
     private PropertyValue propertyValue;
-    @ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToMany(cascade = {CascadeType.DETACH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH}, fetch = FetchType.LAZY)
     @JoinTable(name = "A2_ASSAYPVONTOLOGY",
             joinColumns = @JoinColumn(name = "ASSAYPVID", referencedColumnName = "ASSAYPVID"),
             inverseJoinColumns = @JoinColumn(name = "ONTOLOGYTERMID", referencedColumnName = "ONTOLOGYTERMID"))

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/SampleProperty.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/SampleProperty.java
@@ -53,7 +53,7 @@ public final class SampleProperty {
     @ManyToOne
     @Fetch(FetchMode.SELECT)
     private PropertyValue propertyValue;
-    @ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToMany(cascade = {CascadeType.DETACH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH}, fetch = FetchType.LAZY)
     // TODO: 4alf: this can be expressed in NamingStrategy
     @JoinTable(name = "A2_SAMPLEPVONTOLOGY",
             joinColumns = @JoinColumn(name = "SAMPLEPVID", referencedColumnName = "SAMPLEPVID"),

--- a/atlas-test/src/test/java/uk/ac/ebi/gxa/AbstractIndexNetCDFTestCase.java
+++ b/atlas-test/src/test/java/uk/ac/ebi/gxa/AbstractIndexNetCDFTestCase.java
@@ -69,7 +69,7 @@ public abstract class AbstractIndexNetCDFTestCase extends AtlasDAOTestCase {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
 
         try {
@@ -92,7 +92,7 @@ public abstract class AbstractIndexNetCDFTestCase extends AtlasDAOTestCase {
     }
 
 
-    protected void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
 
         // delete the repo

--- a/atlas-web/pom.xml
+++ b/atlas-web/pom.xml
@@ -283,12 +283,6 @@
 
         <!-- dependencies required by testcases -->
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>${spring.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>uk.ac.ebi.gxa</groupId>
             <artifactId>atlas-index-api</artifactId>
             <type>test-jar</type>

--- a/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
+++ b/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
@@ -33,6 +33,7 @@ http://www.springframework.org/schema/jee/spring-jee-2.5.xsd
 http://www.springframework.org/schema/util
 http://www.springframework.org/schema/util/spring-util.xsd">
     <import resource="classpath*:uk/ac/ebi/gxa/dao/daoContext.xml"/>
+    <import resource="classpath*:uk/ac/ebi/gxa/dao/hibernateContext.xml"/>
     <import resource="classpath*:uk/ac/ebi/gxa/loader/loaderContext.xml"/>
 
     <bean id="threadPool" class="java.util.concurrent.Executors" factory-method="newFixedThreadPool"
@@ -490,11 +491,6 @@ but it uses it to close searcher and clean cache to prevent OOMs -->
     <bean name="atlasNetCDFDAO" class="uk.ac.ebi.gxa.netcdf.reader.AtlasNetCDFDAO">
         <property name="atlasDataRepo" ref="atlasDataRepo"/>
     </bean>
-
-    <!-- Common spring-drive data access configuration -->
-    <!-- native extractor for fetching oracle connections from pool wrapper etc -->
-    <bean name="nativeJdbcExtractor"
-          class="org.springframework.jdbc.support.nativejdbc.CommonsDbcpNativeJdbcExtractor"/>
 
     <!--Configure R workbench -->
     <!-- note that no-arg factory method reads R.properties from classpath, and possibly rservice.properties too -->

--- a/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
+++ b/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
@@ -483,11 +483,6 @@ but it uses it to close searcher and clean cache to prevent OOMs -->
 
     <!-- Required spring driven data access configuration -->
 
-    <!-- Spring JDBC template for database queries -->
-    <bean id="atlasTxManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
-        <property name="dataSource" ref="atlasDataSource"/>
-    </bean>
-
     <bean name="atlasNetCDFDAO" class="uk.ac.ebi.gxa.netcdf.reader.AtlasNetCDFDAO">
         <property name="atlasDataRepo" ref="atlasDataRepo"/>
     </bean>

--- a/atlas-web/src/test/java/uk/ac/ebi/gxa/web/AtlasPlotterTest.java
+++ b/atlas-web/src/test/java/uk/ac/ebi/gxa/web/AtlasPlotterTest.java
@@ -23,6 +23,7 @@
 package uk.ac.ebi.gxa.web;
 
 import ae3.dao.GeneSolrDAO;
+import org.junit.Test;
 import uk.ac.ebi.gxa.AbstractIndexNetCDFTestCase;
 import uk.ac.ebi.microarray.atlas.model.Assay;
 import uk.ac.ebi.microarray.atlas.model.AssayProperty;
@@ -40,7 +41,7 @@ public class AtlasPlotterTest extends AbstractIndexNetCDFTestCase {
     private GeneSolrDAO geneSolrDAO;
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
 
         geneSolrDAO = new GeneSolrDAO();
@@ -53,11 +54,12 @@ public class AtlasPlotterTest extends AbstractIndexNetCDFTestCase {
     }
 
     @Override
-    protected void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         plotter = null;
         super.tearDown();
     }
 
+    @Test
     public void testGetGeneInExpPlotData() throws Exception {
         atlasDAO.startSession();
         final String geneid = getDataSet().getTable("A2_BIOENTITY").getValue(0, "BIOENTITYID").toString();

--- a/indexbuilder/src/test/java/uk/ac/ebi/gxa/index/builder/TestDefaultIndexBuilder.java
+++ b/indexbuilder/src/test/java/uk/ac/ebi/gxa/index/builder/TestDefaultIndexBuilder.java
@@ -30,6 +30,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.core.CoreContainer;
 import org.dbunit.dataset.DataSetException;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -122,6 +123,7 @@ public class TestDefaultIndexBuilder extends AtlasDAOTestCase {
 
     }
 
+    @Test
     public void testBuildIndex() throws InterruptedException, IndexBuilderException {
         // run buildIndex
         indexBuilder.doCommand(new IndexAllCommand(), new IndexBuilderAdapter() {

--- a/indexbuilder/src/test/java/uk/ac/ebi/gxa/index/builder/service/TestExperimentAtlasIndexBuilderService.java
+++ b/indexbuilder/src/test/java/uk/ac/ebi/gxa/index/builder/service/TestExperimentAtlasIndexBuilderService.java
@@ -26,6 +26,7 @@ import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.dbunit.dataset.ITable;
+import org.junit.Test;
 import uk.ac.ebi.gxa.index.builder.IndexAllCommand;
 
 import java.util.Collection;
@@ -56,6 +57,7 @@ public class TestExperimentAtlasIndexBuilderService
         eaibs = null;
     }
 
+    @Test
     public void testCreateIndexDocs() throws Exception {
         // create the docs
         eaibs.build(new IndexAllCommand(), new IndexBuilderService.ProgressUpdater() {

--- a/indexbuilder/src/test/java/uk/ac/ebi/gxa/index/builder/service/TestGeneAtlasIndexBuilderService.java
+++ b/indexbuilder/src/test/java/uk/ac/ebi/gxa/index/builder/service/TestGeneAtlasIndexBuilderService.java
@@ -23,6 +23,7 @@
 package uk.ac.ebi.gxa.index.builder.service;
 
 import org.apache.solr.client.solrj.SolrServerException;
+import org.junit.Test;
 import uk.ac.ebi.gxa.index.builder.IndexAllCommand;
 import uk.ac.ebi.gxa.index.builder.IndexBuilderException;
 import uk.ac.ebi.gxa.properties.AtlasProperties;
@@ -57,6 +58,7 @@ public class TestGeneAtlasIndexBuilderService extends IndexBuilderServiceTestCas
         gaibs = null;
     }
 
+    @Test
     public void testCreateIndexDocs() throws IndexBuilderException, IOException, SolrServerException {
         // create the docs
         gaibs.build(new IndexAllCommand(), new IndexBuilderService.ProgressUpdater() {

--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,12 @@
             <artifactId>spring-jdbc</artifactId>
             <version>${spring.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
Cascading fixed for `AssayProperty` and `SampleProperty`

As a side effect,
- DAO tests are migrated to Spring (Spring is weird when it comes to Hibernate sessions, so it was easier to stick to Spring's way)
- Contexts are split to allow bean definition re-use
- Some of hardcoded bean creation is dropped in favor of Spring XMLs
