### PR TITLE
AtlasProperties is not bound to MyDAS any more

### DIFF
--- a/atlas-utils/pom.xml
+++ b/atlas-utils/pom.xml
@@ -29,20 +29,7 @@
         <version>2.0.9-SNAPSHOT</version>
     </parent>
     <dependencies>
-        <dependency>
-            <groupId>uk.ac.ebi.mydas</groupId>
-            <artifactId>mydas</artifactId>
-            <version>1.6.1_j5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-nop</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- batik for anatomogramms -->
-
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-svggen</artifactId>

--- a/atlas-utils/src/main/java/uk/ac/ebi/gxa/properties/AtlasProperties.java
+++ b/atlas-utils/src/main/java/uk/ac/ebi/gxa/properties/AtlasProperties.java
@@ -25,16 +25,11 @@ package uk.ac.ebi.gxa.properties;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.ReflectionUtils;
 import uk.ac.ebi.gxa.utils.LazyKeylessMap;
-import uk.ac.ebi.mydas.configuration.DataSourceConfiguration;
-import uk.ac.ebi.mydas.configuration.GlobalConfiguration;
-import uk.ac.ebi.mydas.configuration.Mydasserver;
-import uk.ac.ebi.mydas.configuration.ServerConfiguration;
-import uk.ac.ebi.mydas.controller.DataSourceManager;
-import uk.ac.ebi.mydas.controller.MydasServlet;
 
-import java.lang.reflect.Field;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyVetoException;
+import java.beans.VetoableChangeListener;
 import java.util.*;
 
 /**
@@ -58,6 +53,7 @@ public class AtlasProperties {
     }
 
     private final List<AtlasPropertiesListener> listeners = new ArrayList<AtlasPropertiesListener>();
+    private final List<VetoableChangeListener> vetoableChangeListeners = new ArrayList<VetoableChangeListener>();
     private final Map<String, String> cache = new HashMap<String, String>();
 
     /**
@@ -82,11 +78,13 @@ public class AtlasProperties {
      * @param newValue property value or null if property customization should be deleted
      */
     public void setProperty(String key, String newValue) {
-        if (!key.equals("atlas.dasbase") || updateDasBaseURL(newValue)) {
-            // Update atlas.dasbase property only if we managed to MydasServer code was updated successfully
+        try {
+            notifyListeners(key, getProperty(key), newValue);
             storage.setProperty(key, newValue);
             cache.put(key, newValue);
             notifyListeners();
+        } catch (PropertyVetoException e) {
+            log.warn("Property change vetoed", e);
         }
     }
 
@@ -148,9 +146,35 @@ public class AtlasProperties {
         listeners.remove(listener);
     }
 
+    /**
+     * Register property update listener
+     *
+     * @param listener listener reference
+     */
+    public synchronized void registerListener(VetoableChangeListener listener) {
+        if (!vetoableChangeListeners.contains(listener))
+            vetoableChangeListeners.add(listener);
+    }
+
+    /**
+     * Unregister property update listener
+     *
+     * @param listener listener reference
+     */
+    public synchronized void unregisterListener(VetoableChangeListener listener) {
+        vetoableChangeListeners.remove(listener);
+    }
+
     private synchronized void notifyListeners() {
         for (AtlasPropertiesListener listener : listeners)
             listener.onAtlasPropertiesUpdate(this);
+    }
+
+    private synchronized void notifyListeners(String property, String oldValue, String newValue) throws PropertyVetoException {
+        final PropertyChangeEvent event = new PropertyChangeEvent(this, property, oldValue, newValue);
+        for (VetoableChangeListener listener : vetoableChangeListeners) {
+            listener.vetoableChange(event);
+        }
     }
 
     /* Version properties */
@@ -453,61 +477,5 @@ public class AtlasProperties {
      */
     public Integer getMaxEfoMappingsCountForStructuredQuery() {
         return getIntProperty("atlas.structured.query.max.efo.mappings.count");
-    }
-
-    /**
-     * MydasServlet, used by Atlas to expose its data as a DAS source, is configured at start up via MydasServerConfig.xml.
-     * Maven build replaces atlas.dasbase placeholder in MydasServerConfig.xml with a value set in atlas-web/pom.xml
-     * atlas.dasbase property is also configurable via AtlasProperties, but since MydasServlet code does not currently
-     * provide access to its internal fields using atlas.dasbase, the only current way to re-configure MydasServlet code after
-     * an AtlasProperties change to atlas.dasbase is vai the reflection hack below.
-     * TODO replace this method with direct calls to MydasServlet code once setter methods are provided by the DAS team
-     *
-     * @param dasBaseURL base URL for DAS
-     * @return true if all fields were updated via reflection successfully; false otherwise
-     */
-    public boolean updateDasBaseURL(String dasBaseURL) {
-        boolean success = false;
-        try {
-            Field field = ReflectionUtils.findField(MydasServlet.class, "DATA_SOURCE_MANAGER");
-            field.setAccessible(true);
-            Object dataSourceManager = ReflectionUtils.getField(field, null);
-            if (dataSourceManager != null) {
-                // GxaS4DasDataSource has been accessed at least once since Atlas startup and MydasServerConfig.xml was already
-                // read in by MydasServlet - need to update the relevant object fields via reflection
-                // web.xml is now configured to load MydasServlet at Atlas startup - if it is not loaded by the time
-                // this method runs 
-                ServerConfiguration serverConfiguration = ((DataSourceManager) dataSourceManager).getServerConfiguration();
-
-                // Set baseUrl to dasBaseURL - c.f. <baseurl>${atlas.dasbase}/</baseurl> in MydasServerConfig.xml
-                GlobalConfiguration globalConfiguration = serverConfiguration.getGlobalConfiguration();
-                Field baseUrl = globalConfiguration.getClass().getDeclaredField("baseURL");
-                baseUrl.setAccessible(true);
-                baseUrl.set(globalConfiguration, dasBaseURL);
-                log.debug("Setting <baseurl> MydasServerConfig.xml to: dasBaseURL");
-
-                // Update all capability fields with the new dasBaseURL - c.f. (in MydasServerConfig.xml)
-                //    <capability type="das1:sources" query_uri="${atlas.dasbase}/s4" />
-                //    <capability type="das1:types" query_uri="${atlas.dasbase}/s4/types" />
-                //    <capability type="das1:features" query_uri="${atlas.dasbase}/s4/features?segment=ENSG00000162552" />
-                Map<String, DataSourceConfiguration> dataSourceConfigMap = serverConfiguration.getDataSourceConfigMap();
-                for (DataSourceConfiguration dsConfig : dataSourceConfigMap.values()) {
-                    List<Mydasserver.Datasources.Datasource.Version> versions = dsConfig.getConfig().getVersion();
-                    for (Mydasserver.Datasources.Datasource.Version version : versions) {
-                        List<Mydasserver.Datasources.Datasource.Version.Capability> capabilities = version.getCapability();
-                        for (Mydasserver.Datasources.Datasource.Version.Capability capability : capabilities) {
-                            String queryUri = capability.getQueryUri();
-                            String newQueryUri = queryUri.replaceFirst(".*/", dasBaseURL + "/");
-                            log.debug("Setting query_uri of capability type: " + capability.getType() + " in MydasServerConfig.xml to " + newQueryUri);
-                            capability.setQueryUri(newQueryUri);
-                        }
-                    }
-                }
-                success = true;
-            }
-        } catch (Exception e) {
-            log.error("Failed to update dasBaseUrl to : " + dasBaseURL, e);
-        }
-        return success;
     }
 }

--- a/atlas-web/src/main/java/ae3/service/MydasGxaServlet.java
+++ b/atlas-web/src/main/java/ae3/service/MydasGxaServlet.java
@@ -1,11 +1,26 @@
 package ae3.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 import uk.ac.ebi.gxa.properties.AtlasProperties;
+import uk.ac.ebi.mydas.configuration.DataSourceConfiguration;
+import uk.ac.ebi.mydas.configuration.GlobalConfiguration;
+import uk.ac.ebi.mydas.configuration.Mydasserver;
+import uk.ac.ebi.mydas.configuration.ServerConfiguration;
+import uk.ac.ebi.mydas.controller.DataSourceManager;
 import uk.ac.ebi.mydas.controller.MydasServlet;
 
 import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyVetoException;
+import java.beans.VetoableChangeListener;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This class behaves like {@link MydasServlet}, except for slotting in its own {@link ServletContext}&mdash;
@@ -13,7 +28,15 @@ import javax.servlet.ServletContext;
  *
  * @see MydasGxaServletContext
  */
-public class MydasGxaServlet extends MydasServlet {
+public class MydasGxaServlet extends MydasServlet implements VetoableChangeListener {
+    private static final Logger log = LoggerFactory.getLogger(MydasGxaServlet.class);
+
+    @Override
+    public void init() throws ServletException {
+        getAtlasPropertiesBean(getServletContext()).registerListener(this);
+        super.init();
+    }
+
     @Override
     public ServletContext getServletContext() {
         ServletContext parentContext = super.getServletContext();
@@ -26,5 +49,70 @@ public class MydasGxaServlet extends MydasServlet {
 
     private static WebApplicationContext getSpringApplicationContext(ServletContext servletContext) {
         return WebApplicationContextUtils.getRequiredWebApplicationContext(servletContext);
+    }
+
+    /**
+     * MydasServlet, used by Atlas to expose its data as a DAS source, is configured at start up via MydasServerConfig.xml.
+     * Maven build replaces atlas.dasbase placeholder in MydasServerConfig.xml with a value set in atlas-web/pom.xml
+     * atlas.dasbase property is also configurable via AtlasProperties, but since MydasServlet code does not currently
+     * provide access to its internal fields using atlas.dasbase, the only current way to re-configure MydasServlet code after
+     * an AtlasProperties change to atlas.dasbase is vai the reflection hack below.
+     * TODO replace this method with direct calls to MydasServlet code once setter methods are provided by the DAS team
+     *
+     * @param dasBaseURL base URL for DAS
+     * @return true if all fields were updated via reflection successfully; false otherwise
+     */
+    public boolean updateDasBaseURL(String dasBaseURL) {
+        boolean success = false;
+        try {
+            Field field = ReflectionUtils.findField(MydasServlet.class, "DATA_SOURCE_MANAGER");
+            field.setAccessible(true);
+            Object dataSourceManager = ReflectionUtils.getField(field, null);
+            if (dataSourceManager != null) {
+                // GxaS4DasDataSource has been accessed at least once since Atlas startup and MydasServerConfig.xml was already
+                // read in by MydasServlet - need to update the relevant object fields via reflection
+                // web.xml is now configured to load MydasServlet at Atlas startup - if it is not loaded by the time
+                // this method runs
+                ServerConfiguration serverConfiguration = ((DataSourceManager) dataSourceManager).getServerConfiguration();
+
+                // Set baseUrl to dasBaseURL - c.f. <baseurl>${atlas.dasbase}/</baseurl> in MydasServerConfig.xml
+                GlobalConfiguration globalConfiguration = serverConfiguration.getGlobalConfiguration();
+                Field baseUrl = globalConfiguration.getClass().getDeclaredField("baseURL");
+                baseUrl.setAccessible(true);
+                baseUrl.set(globalConfiguration, dasBaseURL);
+                log.debug("Setting <baseurl> MydasServerConfig.xml to: dasBaseURL");
+
+                // Update all capability fields with the new dasBaseURL - c.f. (in MydasServerConfig.xml)
+                //    <capability type="das1:sources" query_uri="${atlas.dasbase}/s4" />
+                //    <capability type="das1:types" query_uri="${atlas.dasbase}/s4/types" />
+                //    <capability type="das1:features" query_uri="${atlas.dasbase}/s4/features?segment=ENSG00000162552" />
+                Map<String, DataSourceConfiguration> dataSourceConfigMap = serverConfiguration.getDataSourceConfigMap();
+                for (DataSourceConfiguration dsConfig : dataSourceConfigMap.values()) {
+                    List<Mydasserver.Datasources.Datasource.Version> versions = dsConfig.getConfig().getVersion();
+                    for (Mydasserver.Datasources.Datasource.Version version : versions) {
+                        List<Mydasserver.Datasources.Datasource.Version.Capability> capabilities = version.getCapability();
+                        for (Mydasserver.Datasources.Datasource.Version.Capability capability : capabilities) {
+                            String queryUri = capability.getQueryUri();
+                            String newQueryUri = queryUri.replaceFirst(".*/", dasBaseURL + "/");
+                            log.debug("Setting query_uri of capability type: " + capability.getType() + " in MydasServerConfig.xml to " + newQueryUri);
+                            capability.setQueryUri(newQueryUri);
+                        }
+                    }
+                }
+                success = true;
+            }
+        } catch (Exception e) {
+            log.error("Failed to update dasBaseUrl to : " + dasBaseURL, e);
+        }
+        return success;
+    }
+
+    @Override
+    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
+        if ("atlas.dasbase".equals(evt.getPropertyName())) {
+            final boolean success = updateDasBaseURL((String) evt.getNewValue());
+            if (!success)
+                throw new PropertyVetoException("Cannot update DAS base to " + evt.getNewValue(), evt);
+        }
     }
 }

--- a/atlas-web/src/main/java/ae3/service/MydasGxaServlet.java
+++ b/atlas-web/src/main/java/ae3/service/MydasGxaServlet.java
@@ -23,8 +23,12 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * This class behaves like {@link MydasServlet}, except for slotting in its own {@link ServletContext}&mdash;
- * for more information on the rationale see {@link MydasGxaServletContext}.
+ * {@link MydasServlet} tailored for Atlas
+ * <p/>
+ * This class behaves like {@link MydasServlet}, except for slotting in its own {@link ServletContext} and listening for
+ * {@link AtlasProperties} changes.
+ * <p/>
+ * For more information on the rationale see {@link MydasGxaServletContext}.
  *
  * @see MydasGxaServletContext
  */
@@ -58,6 +62,11 @@ public class MydasGxaServlet extends MydasServlet implements VetoableChangeListe
      * provide access to its internal fields using atlas.dasbase, the only current way to re-configure MydasServlet code after
      * an AtlasProperties change to atlas.dasbase is vai the reflection hack below.
      * TODO replace this method with direct calls to MydasServlet code once setter methods are provided by the DAS team
+     * <p/>
+     * It would be nice to re-init the MydasServlet using standard {@link javax.servlet.Servlet#destroy()} and
+     * {@link javax.servlet.Servlet#init} methods, but unfortunately the settings are stored in a static field
+     * which gets destroyed but not cleared. Hence, the reflection tricks are still necessary,
+     * which in turn makes re-init cycle senseless.
      *
      * @param dasBaseURL base URL for DAS
      * @return true if all fields were updated via reflection successfully; false otherwise


### PR DESCRIPTION
It was a weird situation when one of the core classes was bound to the internals of a third-party code. As a side  effect, each test run would create five huge log files impacting text search.

Extracted MyDAS-specific code into MyDAS classes and replaced explicit MyDAS call with `VetoableChangeListener` notification.
