### PR TITLE
Ticket #3042 Non-formatted date on experiment index page (pre-release 2.0.9)

### DIFF
--- a/atlas-web/src/main/webapp/WEB-INF/jsp/experimentpage/experiment-index.jsp
+++ b/atlas-web/src/main/webapp/WEB-INF/jsp/experimentpage/experiment-index.jsp
@@ -97,7 +97,7 @@
                     <a href="${pageContext.request.contextPath}/experiment/${experiment.accession}">${experiment.accession}</a>
                 </display:column>
                 <display:column property="loadDate" sortable="true" sortName="loaddate"
-                                title="Loaded" class="nowrap"/>
+                                title="Loaded" class="nowrap" format="{0,date,dd-MM-yyyy}"/>
                 <display:column property="description" sortable="false"/>
                 <display:column sortable="true" sortName="pmid" title="PubMed ID"
                                 class="number">


### PR DESCRIPTION
After moving to hibernate the date is returned as java.util.Date instead of java.sql.Timestamp. So default toString(..) method doesn't work any more (I guess). I set the format for the date field explicitly (example of using formatted column in display tag is here http://demo.displaytag.org/displaytag-examples-1.1/example-format.jsp ). 

ready to review
