### PR TITLE
Getting rid of hilo strategy in Hibernate's annotations

### DIFF
--- a/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/TestAtlasDAO.java
+++ b/atlas-dao/src/test/java/uk/ac/ebi/gxa/dao/TestAtlasDAO.java
@@ -123,8 +123,8 @@ public class TestAtlasDAO extends AtlasDAOTestCase {
         String accession =
                 getDataSet().getTable("A2_ARRAYDESIGN").getValue(0, "accession")
                         .toString();
-        long id =
-                Long.parseLong(getDataSet().getTable("A2_ARRAYDESIGN")
+        Long id =
+                Long.valueOf(getDataSet().getTable("A2_ARRAYDESIGN")
                         .getValue(0, "arraydesignid")
                         .toString());
 

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/ArrayDesign.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/ArrayDesign.java
@@ -35,8 +35,8 @@ import static java.util.Collections.singletonList;
 public class ArrayDesign {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "arrayDesignSeq")
-    @SequenceGenerator(name = "arrayDesignSeq", sequenceName = "A2_ARRAYDESIGN_SEQ")
-    private long arrayDesignID;
+    @SequenceGenerator(name = "arrayDesignSeq", sequenceName = "A2_ARRAYDESIGN_SEQ", allocationSize = 1)
+    private Long arrayDesignID;
     private String accession;
     private String name;
     private String provider;
@@ -87,11 +87,11 @@ public class ArrayDesign {
         this.type = type;
     }
 
-    public long getArrayDesignID() {
+    public Long getArrayDesignID() {
         return arrayDesignID;
     }
 
-    public void setArrayDesignID(long arrayDesignID) {
+    public void setArrayDesignID(Long arrayDesignID) {
         this.arrayDesignID = arrayDesignID;
     }
 

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Assay.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Assay.java
@@ -66,7 +66,7 @@ public class Assay {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "assaySeq")
-    @SequenceGenerator(name = "assaySeq", sequenceName = "A2_ASSAY_SEQ")
+    @SequenceGenerator(name = "assaySeq", sequenceName = "A2_ASSAY_SEQ", allocationSize = 1)
     private Long assayID;
     private String accession;
 

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/AssayProperty.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/AssayProperty.java
@@ -43,7 +43,7 @@ import static java.util.Collections.unmodifiableList;
 public final class AssayProperty {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "assayPVSeq")
-    @SequenceGenerator(name = "assayPVSeq", sequenceName = "A2_ASSAYPV_SEQ")
+    @SequenceGenerator(name = "assayPVSeq", sequenceName = "A2_ASSAYPV_SEQ", allocationSize = 1)
     private Long assaypvid;
     @ManyToOne
     @Fetch(FetchMode.SELECT)

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Asset.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Asset.java
@@ -39,7 +39,7 @@ import javax.persistence.*;
 public class Asset {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "assetSeq")
-    @SequenceGenerator(name = "assetSeq", sequenceName = "A2_ASSET_SEQ")
+    @SequenceGenerator(name = "assetSeq", sequenceName = "A2_ASSET_SEQ", allocationSize = 1)
     private Long experimentassetid;
     @ManyToOne
     @Fetch(FetchMode.SELECT)

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
@@ -43,7 +43,7 @@ import static uk.ac.ebi.gxa.utils.DateUtil.copyOf;
 public class Experiment {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "experimentSeq")
-    @SequenceGenerator(name = "experimentSeq", sequenceName = "A2_EXPERIMENT_SEQ")
+    @SequenceGenerator(name = "experimentSeq", sequenceName = "A2_EXPERIMENT_SEQ", allocationSize = 1)
     private Long experimentid;
     private String accession;
 

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Ontology.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Ontology.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 public class Ontology {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ontologySeq")
-    @SequenceGenerator(name = "ontologySeq", sequenceName = "A2_ONTOLOGY_SEQ")
+    @SequenceGenerator(name = "ontologySeq", sequenceName = "A2_ONTOLOGY_SEQ", allocationSize = 1)
     private Long ontologyid;
     private String name;
     @Column(name = "SOURCE_URI")

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/OntologyTerm.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/OntologyTerm.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 public class OntologyTerm {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ontologyTermSeq")
-    @SequenceGenerator(name = "ontologyTermSeq", sequenceName = "A2_ONTOLOGYTERM_SEQ")
+    @SequenceGenerator(name = "ontologyTermSeq", sequenceName = "A2_ONTOLOGYTERM_SEQ", allocationSize = 1)
     private Long ontologytermid;
     @ManyToOne
     private Ontology ontology;

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Organism.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Organism.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 public class Organism {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "organismSeq")
-    @SequenceGenerator(name = "organismSeq", sequenceName = "A2_ORGANISM_SEQ")
+    @SequenceGenerator(name = "organismSeq", sequenceName = "A2_ORGANISM_SEQ", allocationSize = 1)
     private Long organismid;
     private String name;
 

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Property.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Property.java
@@ -16,7 +16,7 @@ import java.util.List;
 public final class Property {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "propertySeq")
-    @SequenceGenerator(name = "propertySeq", sequenceName = "A2_PROPERTY_SEQ")
+    @SequenceGenerator(name = "propertySeq", sequenceName = "A2_PROPERTY_SEQ", allocationSize = 1)
     private Long propertyid;
     private String name;
     @OneToMany(targetEntity = PropertyValue.class, mappedBy = "property", orphanRemoval = true)

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/PropertyValue.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/PropertyValue.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 public final class PropertyValue {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "propertyValueSeq")
-    @SequenceGenerator(name = "propertyValueSeq", sequenceName = "A2_PROPERTYVALUE_SEQ")
+    @SequenceGenerator(name = "propertyValueSeq", sequenceName = "A2_PROPERTYVALUE_SEQ", allocationSize = 1)
     private Long propertyvalueid;
     @ManyToOne
     private Property property;

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Sample.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Sample.java
@@ -51,7 +51,7 @@ public class Sample {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sampleSeq")
-    @SequenceGenerator(name = "sampleSeq", sequenceName = "A2_SAMPLE_SEQ")
+    @SequenceGenerator(name = "sampleSeq", sequenceName = "A2_SAMPLE_SEQ", allocationSize = 1)
     private Long sampleid;
     private String accession;
     @ManyToOne

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/SampleProperty.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/SampleProperty.java
@@ -45,7 +45,7 @@ import static java.util.Collections.unmodifiableList;
 public final class SampleProperty {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "samplePVSeq")
-    @SequenceGenerator(name = "samplePVSeq", sequenceName = "A2_SAMPLEPV_SEQ")
+    @SequenceGenerator(name = "samplePVSeq", sequenceName = "A2_SAMPLEPV_SEQ", allocationSize = 1)
     private Long samplepvid;
     @ManyToOne
     @Fetch(FetchMode.SELECT)

--- a/atlas-web/src/test/java/ae3/dao/ExperimentalDataTest.java
+++ b/atlas-web/src/test/java/ae3/dao/ExperimentalDataTest.java
@@ -29,8 +29,8 @@ import uk.ac.ebi.gxa.netcdf.reader.AtlasNetCDFDAO;
 import uk.ac.ebi.gxa.web.filter.ResourceWatchdogFilter;
 import uk.ac.ebi.microarray.atlas.model.ArrayDesign;
 import uk.ac.ebi.microarray.atlas.model.Assay;
-import uk.ac.ebi.microarray.atlas.model.Sample;
 import uk.ac.ebi.microarray.atlas.model.Experiment;
+import uk.ac.ebi.microarray.atlas.model.Sample;
 
 import java.io.File;
 import java.io.IOException;
@@ -113,7 +113,7 @@ public class ExperimentalDataTest {
     public void testLoadExperiment() throws IOException, URISyntaxException {
         Experiment eMexp1586 = new Experiment(1036805754L, "E-MEXP-1586");
         ArrayDesign ad1 = new ArrayDesign();
-        ad1.setArrayDesignID(160588088);
+        ad1.setArrayDesignID(160588088L);
         ad1.setAccession("A-AFFY-44");
         eMexp1586.setAssays(eMexp1586Assays(eMexp1586, ad1));
         eMexp1586.setSamples(eMexp1586Samples());
@@ -130,10 +130,10 @@ public class ExperimentalDataTest {
     public void testMultiArrayDesign() throws IOException, URISyntaxException {
         Experiment eMexp1913 = new Experiment(1036804993L, "E-MEXP-1913");
         ArrayDesign ad21 = new ArrayDesign();
-        ad21.setArrayDesignID(153069949);
+        ad21.setArrayDesignID(153069949L);
         ad21.setAccession("A-AFFY-33");
         ArrayDesign ad22 = new ArrayDesign();
-        ad22.setArrayDesignID(165554923);
+        ad22.setArrayDesignID(165554923L);
         ad22.setAccession("A-AFFY-44");
         List<Assay> assays = eMexp1913Assays1(eMexp1913, ad21);
         assays.addAll(eMexp1913Assays2(eMexp1913, ad22));

--- a/sql/updates/2.0.8-2.0.9/20110816-1-update_atlasmgr_fix_sequences.sql
+++ b/sql/updates/2.0.8-2.0.9/20110816-1-update_atlasmgr_fix_sequences.sql
@@ -183,5 +183,7 @@ END;
 END;
 /
 
+call ATLASMGR.RebuildSequences();
+
 -- Will be done by script runner from the next version on
 insert into A2_SCHEMACHANGES values (null, '20110816-1-update_atlasmgr_fix_sequences.sql', 'alf', CURRENT_TIMESTAMP);

--- a/sql/updates/2.0.8-2.0.9/20110816-1-update_atlasmgr_fix_sequences.sql
+++ b/sql/updates/2.0.8-2.0.9/20110816-1-update_atlasmgr_fix_sequences.sql
@@ -1,0 +1,187 @@
+-- Estimated running time: 2 seconds
+
+/*
+ * Copyright 2008-2010 Microarray Informatics Team, EMBL-European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * For further details of the Gene Expression Atlas project, including source code,
+ * downloads and documentation, please see:
+ *
+ * http://gxa.github.com/gxa/
+ */
+
+CREATE OR REPLACE PACKAGE ATLASMGR IS
+  PROCEDURE DisableConstraints;
+  PROCEDURE EnableConstraints;
+  PROCEDURE DisableTriggers;
+  PROCEDURE EnableTriggers;
+  PROCEDURE RebuildSequence(seq_name varchar2);
+  PROCEDURE RebuildSequences;
+  PROCEDURE RebuildIndex;
+  PROCEDURE fix_sequence(tbl VARCHAR2, field VARCHAR2, seq VARCHAR2);
+END ATLASMGR;
+/
+
+/*******************************************************************************
+/*******************************************************************************/
+CREATE OR REPLACE PACKAGE BODY ATLASMGR AS
+
+--------------------------------------------------------------------------------
+PROCEDURE DisableConstraints
+AS
+ cursor c1 is select CONSTRAINT_NAME, TABLE_NAME from user_constraints where constraint_type = 'R';
+ q varchar2(8000);
+begin
+
+for rec in c1
+ loop
+    q := 'ALTER TABLE ' || rec.TABLE_NAME  || ' DISABLE CONSTRAINT ' || rec.CONSTRAINT_NAME;
+
+    dbms_output.put_line(q);
+
+    EXECUTE IMMEDIATE q;
+ end loop;
+END;
+--------------------------------------------------------------------------------
+PROCEDURE EnableConstraints
+AS
+ cursor c1 is select CONSTRAINT_NAME, TABLE_NAME
+              from user_constraints
+              where constraint_type = 'R'
+              and CONSTRAINT_NAME <> 'FK_EV_DESIGNELEMENT'; --orphane ev in release 10.3
+ q varchar2(8000);
+begin
+ delete from A2_ASSAYPVONTOLOGY where ASSAYPVID = 0;
+ delete from A2_SAMPLEPVONTOLOGY where SAMPLEPVID  = 0;
+
+for rec in c1
+ loop
+    q := 'ALTER TABLE ' || rec.TABLE_NAME  || ' ENABLE CONSTRAINT ' || rec.CONSTRAINT_NAME;
+
+    dbms_output.put_line(q);
+
+    EXECUTE IMMEDIATE q;
+ end loop;
+END;
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+PROCEDURE DisableTriggers
+AS
+ cursor c1 is select TRIGGER_NAME from user_triggers;
+ q varchar2(8000);
+begin
+for rec in c1
+ loop
+    q := 'ALTER TRIGGER ' || rec.TRIGGER_NAME  || ' DISABLE';
+
+    dbms_output.put_line(q);
+
+    EXECUTE IMMEDIATE q;
+ end loop;
+END;
+--------------------------------------------------------------------------------
+PROCEDURE EnableTriggers
+AS
+ cursor c1 is select TRIGGER_NAME from user_triggers;
+ q varchar2(8000);
+begin
+for rec in c1
+ loop
+    q := 'ALTER TRIGGER ' || rec.TRIGGER_NAME  || ' ENABLE';
+
+    dbms_output.put_line(q);
+
+    EXECUTE IMMEDIATE q;
+ end loop;
+END;
+--------------------------------------------------------------------------------
+
+PROCEDURE fix_sequence(tbl VARCHAR2, field VARCHAR2, seq VARCHAR2)
+AS
+  current_id  NUMBER;
+  current_seq NUMBER;
+BEGIN
+  EXECUTE immediate 'select max(' || field || ') from ' || tbl into current_id;
+  EXECUTE immediate 'select ' || seq || '.nextval from dual' into current_seq;
+  IF (current_id > current_seq) THEN
+    EXECUTE immediate 'alter sequence ' || seq || ' increment by ' || to_char(current_id - current_seq);
+    EXECUTE immediate 'select ' || seq || '.nextval from dual' into current_seq;
+    EXECUTE immediate 'alter sequence ' || seq || ' increment by 1';
+  END IF;
+END;
+
+procedure RebuildSequence(seq_name varchar2)
+AS
+ TABLE_NAME varchar2(255);
+ PK_NAME varchar2(255);
+begin
+    TABLE_NAME := REPLACE(seq_name, '_SEQ', '');
+
+    select c.COLUMN_NAME into PK_NAME
+    from user_tab_columns c
+    join user_constraints k on k.table_name = c.table_name
+    join user_indexes i on i.INDEX_NAME = k.INDEX_NAME and i.TABLE_NAME = k.TABLE_NAME
+    join user_ind_columns ic on ic.INDEX_NAME = i.INDEX_NAME and ic.TABLE_NAME = i.TABLE_NAME
+    where ic.COLUMN_NAME = c.COLUMN_NAME
+    and k.constraint_type ='P'
+    and k.TABLE_NAME = REBUILDSEQUENCE.TABLE_NAME;
+
+    fix_sequence(TABLE_NAME, PK_NAME, seq_name);
+exception
+  when NO_DATA_FOUND then
+    dbms_output.put_line('No data for ' ||  seq_name || ' - please report');
+end;
+
+
+/*******************************************************************************
+rebuilding sequences for all tables in schema
+
+naming conventions and DB structure assumptions:
+Each table has one autoincrement PK, updated in trigger from corresponding
+sequence. SEQUENCE_NAME = TABLE_NAME || "_SEQ"
+
+call RebuildSequence();
+********************************************************************************/
+procedure RebuildSequences
+AS
+ cursor c1 is select SEQUENCE_NAME, LAST_NUMBER from user_sequences;
+begin
+ for rec in c1
+ loop
+    RebuildSequence(rec.SEQUENCE_NAME);
+ END LOOP;
+END;
+
+--call ATLASMGR.RebuildIndex()
+procedure RebuildIndex
+AS
+ cursor c1 is select INDEX_NAME from user_indexes;
+ q varchar2(8000);
+BEGIN
+ for rec in c1
+ loop
+  q := 'ALTER INDEX $INDEX_NAME REBUILD';
+  q := REPLACE(q,'$INDEX_NAME',rec.INDEX_NAME);
+  dbms_output.put_line(q);
+  Execute immediate q;
+
+ end loop;
+END;
+
+END;
+/
+
+-- Will be done by script runner from the next version on
+insert into A2_SCHEMACHANGES values (null, '20110816-1-update_atlasmgr_fix_sequences.sql', 'alf', CURRENT_TIMESTAMP);


### PR DESCRIPTION
- setting `allocationSize = 1` in order to disable Hibernate's hilo approach (which is nice, but not ready for our DB yet)
- adding script to update `ATLASMGR` (it was apparently out-of-date in curators' instance)
- as the bug with `hilo` approach could get sequences out of sync with the tables, it won't hurt running `RebuildSequences()` just to be sure (it's idempotent, anyway)
- to facilitate the merge, made `arrayDesignID` `Long` rather than `long`
