### PR TITLE
Ticket#3060 Highlighting in search results is broken

### DIFF
--- a/atlas-web/src/main/java/ae3/service/structuredquery/AtlasStructuredQueryService.java
+++ b/atlas-web/src/main/java/ae3/service/structuredquery/AtlasStructuredQueryService.java
@@ -26,7 +26,6 @@ import ae3.model.AtlasGene;
 import ae3.model.ListResultRow;
 import ae3.model.ListResultRowExperiment;
 import ae3.service.AtlasStatisticsQueryService;
-import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.HashMultiset;
@@ -65,6 +64,7 @@ import uk.ac.ebi.microarray.atlas.model.UpDownExpression;
 
 import java.util.*;
 
+import static com.google.common.base.Joiner.on;
 import static uk.ac.ebi.gxa.exceptions.LogUtil.createUnexpected;
 
 
@@ -690,7 +690,7 @@ public class AtlasStructuredQueryService implements IndexBuilderEventHandler, Di
                 controlCache();
 
                 SolrQuery q = setupSolrQuery(query.getRowsPerPage(), qstate);
-                q.addFilterQuery("id:(" + Joiner.on(" ").join(genesByConditions) + ")");
+                q.addFilterQuery("id:(" + on(" ").join(genesByConditions) + ")");
                 long timeStart = System.currentTimeMillis();
 
                 QueryResponse response = solrServerAtlas.query(q);

--- a/atlas-web/src/main/java/ae3/service/structuredquery/AtlasStructuredQueryService.java
+++ b/atlas-web/src/main/java/ae3/service/structuredquery/AtlasStructuredQueryService.java
@@ -1774,13 +1774,24 @@ public class AtlasStructuredQueryService implements IndexBuilderEventHandler, Di
         SolrQuery q = new SolrQuery(qstate.getSolrq().toString());
 
         q.setRows(rowsPerPage);
-        q.setIncludeScore(true);
+        q.setFacet(true);
+
+        int max = 0;
+        q.addField("score");
         q.addField("id");
         q.addField("name");
         q.addField("identifier");
         q.addField("species");
         for (String p : genePropService.getIdNameDescProperties())
             q.addField("property_" + p);
+        q.setFacetLimit(5 + max);
+        q.setFacetMinCount(2);
+
+        for (String p : genePropService.getDrilldownProperties()) {
+            q.addFacetField("property_f_" + p);
+        }
+
+        q.addFacetField("species");
 
         q.setHighlight(true);
         q.setHighlightSnippets(100);


### PR DESCRIPTION
Highlighting was broken, because the solr query was splited into two (long time ago) to filter found genes by experiment and conditions. To fix highlighting the second query was changed a bit: it includes search by name and properties, but filtered by pre-found gene ids.
