### PR TITLE
Ticket #3071 Weird rounding in JSON/XML API output

### DIFF
--- a/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/FloatFormatter.java
+++ b/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/FloatFormatter.java
@@ -22,6 +22,8 @@
 
 package uk.ac.ebi.gxa.utils;
 
+import java.math.BigDecimal;
+
 import static java.lang.Math.*;
 
 public final class FloatFormatter {
@@ -55,7 +57,9 @@ public final class FloatFormatter {
             return 0;
 
         int order = (int) ceil(log10(abs(value)));
-        final double precision = pow(10.0, order - significantDigits);
-        return round(value / precision) * precision;
+        return (new BigDecimal(value))
+                .scaleByPowerOfTen(-order)
+                .setScale(significantDigits, BigDecimal.ROUND_HALF_UP)
+                .scaleByPowerOfTen(order).doubleValue();
     }
 }

--- a/atlas-utils/src/test/java/uk/ac/ebi/gxa/utils/FloatFormatterTest.java
+++ b/atlas-utils/src/test/java/uk/ac/ebi/gxa/utils/FloatFormatterTest.java
@@ -29,5 +29,7 @@ public class FloatFormatterTest {
         assertEquals("-2.75E-6", FloatFormatter.formatFloat(-2.748345E-6F, 3));
         assertEquals("0.0", FloatFormatter.formatFloat(2.748345E-11F, 3));
         assertEquals("0.0", FloatFormatter.formatFloat(-2.748345E-11F, 3));
+        assertEquals("69.1", FloatFormatter.formatFloat(69.12F, 3));
+        assertEquals("86.6", FloatFormatter.formatFloat(86.6F, 3));
     }
 }


### PR DESCRIPTION
Floating point number representation is not exact for some numbers, e.g. 0.1, so using BigDecimal now.
