### PR TITLE
Ticket #3070 Currently displayed factor not highlighted on gene page

### DIFF
--- a/atlas-web/src/main/webapp/WEB-INF/jsp/genepage/experiment-list-page.jsp
+++ b/atlas-web/src/main/webapp/WEB-INF/jsp/genepage/experiment-list-page.jsp
@@ -64,7 +64,7 @@
                     <div class="header" style="padding-top: 5px;padding-bottom: 5px; valign:middle">
                         <span>Experimental Factors</span>
 
-                        <div id="${exp.id}_EFpagination" class="pagination_ie" style="padding-top: 10px;">
+                        <div id="${exp.accession}_EFpagination" class="pagination_ie" style="padding-top: 10px;">
                             <c:forEach var="EF" items="${exp.experimentFactors}">
                                 <a id="${EF}"
                                    onclick="redrawPlotForFactor('${exp.id}','${exp.accession}', '${atlasGene.geneId}','${EF}',false)">${f:escapeXml(atlasProperties.curatedEfs[EF])}</a>


### PR DESCRIPTION
We missed one of experiment.id to experiment.accession substitutions on gene page during one of our "major" code refactoring long time ago 

[http://bar.ebi.ac.uk:8080/trac/ticket/3070]
