### PR TITLE
Ticket #2988 EB-eye Search Link needs to be replaced with smth more current

### DIFF
--- a/atlas-web/src/main/webapp/WEB-INF/jsp/genepage/gene.jsp
+++ b/atlas-web/src/main/webapp/WEB-INF/jsp/genepage/gene.jsp
@@ -391,7 +391,7 @@ $(document).ready(function() {
                     <td class="geneAnnotHeader">Search EB-eye</td>
                     <td align="left">
                         <a title="Show gene annotation" target="_blank"
-                           href="http://www.ebi.ac.uk/ebisearch/search.ebi?db=genomes&t=${atlasGene.geneIdentifier}">
+                           href="http://www.ebi.ac.uk/ebisearch/search.ebi?db=allebi&query=${atlasGene.geneIdentifier}&requestFrom=ebi_index&submit=+FIND+">
                             ${atlasGene.geneIdentifier}
                         </a>
                     </td>


### PR DESCRIPTION
Search EB-eye link is set to  http://www.ebi.ac.uk/ebisearch/search.ebi?db=allebi&query=${atlasGene.geneIdentifier}&requestFrom=ebi_index&submit=+FIND+.
