### PR TITLE
Transactions

### DIFF
--- a/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
+++ b/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
@@ -165,7 +165,7 @@ http://www.springframework.org/schema/util/spring-util.xsd">
         <property name="atlasDAO" ref="atlasDAO"/>
         <property name="atlasIndex" ref="atlasIndex"/>
         <property name="atlasDataDAO" ref="atlasDataDAO"/>
-        <constructor-arg value="bitstats"/>
+        <property name="indexFileName" value="bitstats"/>
     </bean>
 
     <bean name="indexBuilder" class="uk.ac.ebi.gxa.index.builder.DefaultIndexBuilder">

--- a/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/GeneAtlasBitIndexBuilderService.java
+++ b/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/GeneAtlasBitIndexBuilderService.java
@@ -35,7 +35,7 @@ import static java.util.Collections.sort;
  */
 public class GeneAtlasBitIndexBuilderService extends IndexBuilderService {
     private AtlasDataDAO atlasDataDAO;
-    private final String indexFileName;
+    private String indexFileName;
     private File atlasIndex;
     private File indexFile = null;
 
@@ -49,12 +49,7 @@ public class GeneAtlasBitIndexBuilderService extends IndexBuilderService {
         this.atlasIndex = atlasIndex;
     }
 
-    /**
-     * Constructor
-     *
-     * @param indexFileName name of the serialized index file
-     */
-    public GeneAtlasBitIndexBuilderService(String indexFileName) {
+    public void setIndexFileName(String indexFileName) {
         this.indexFileName = indexFileName;
     }
 

--- a/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/GeneAtlasBitIndexBuilderService.java
+++ b/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/GeneAtlasBitIndexBuilderService.java
@@ -60,12 +60,14 @@ public class GeneAtlasBitIndexBuilderService extends IndexBuilderService {
 
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processCommand(IndexAllCommand indexAll,
                                IndexBuilderService.ProgressUpdater progressUpdater) throws IndexBuilderException {
         indexAll(progressUpdater);
     }
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processCommand(UpdateIndexForExperimentCommand cmd,
                                IndexBuilderService.ProgressUpdater progressUpdater) throws IndexBuilderException {
         /// Re-build the whole bit index even if one experiment only is being updated
@@ -108,7 +110,6 @@ public class GeneAtlasBitIndexBuilderService extends IndexBuilderService {
      * @param progressLogFreq how often this operation should be logged (i.e. every progressLogFreq ncfds processed)
      * @return StatisticsStorage containing statistics for all statistics types in StatisticsType enum - collected over all Atlas data
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     private StatisticsStorage bitIndexExperiments(final ProgressUpdater progressUpdater,
                                                   final Integer progressLogFreq) {
         StatisticsStorage statisticsStorage = new StatisticsStorage();


### PR DESCRIPTION
As per http://forum.springsource.org/showthread.php?57763-Transactional-on-private-methods 

  Only external method calls can be intercepted (as explained in [the reference guide](http://static.springsource.org/spring/docs/3.0.5.RELEASE/reference/transaction.html#transaction-declarative-annotations)) so marking private methods with `@Transactional` doesn't do anything.

See the  [10.5.6 Using `@Transactional`](http://static.springsource.org/spring/docs/3.0.5.RELEASE/reference/transaction.html#transaction-declarative-annotations):

You can place the `@Transactional` annotation before an interface definition, a method on an interface, a class definition, or a _public_ method on a class. 
