### PR TITLE
Trac 3132: AIOOBE 

### DIFF
--- a/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/NetCDFProxy.java
+++ b/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/NetCDFProxy.java
@@ -367,6 +367,21 @@ public final class NetCDFProxy implements Closeable {
         return list;
     }
 
+    /**
+     * This method is intentionally ugly-named and ugly itself.
+     * <p/>
+     * It returns an <em>unfiltered</em> list of unique values, which is used as a parallel structure when we
+     * work with <code>PVAL</code> and <code>TSTAT</code>.
+     * <p/>
+     * For further details, refer to the <a href="http://bar.ebi.ac.uk:8080/trac/ticket/3132">ticket 3132</a>
+     * <p/>
+     * It is _obviously_ not the best solution, but it fixes this problem, this problem only,
+     * and, as far as I know, does not introduce new problems, which is nice.
+     *
+     * @return an <em>unfiltered</em> list of unique values
+     * @throws IOException        in case of I/O errors
+     * @throws AtlasDataException in case of any other errors during NetCDF handling
+     */
     public List<KeyValuePair> getUVal() throws IOException, AtlasDataException {
         Variable uVALVar;
         uVALVar = netCDF.findVariable("uVAL");

--- a/atlas-data-storage/src/test/java/uk/ac/ebi/gxa/data/TestNetCDFProxy.java
+++ b/atlas-data-storage/src/test/java/uk/ac/ebi/gxa/data/TestNetCDFProxy.java
@@ -118,7 +118,7 @@ public class TestNetCDFProxy extends TestCase {
         Set<KeyValuePair> uniques = new HashSet<KeyValuePair>();
         List<KeyValuePair> uVals = netCDF.getUniqueValues();
         List<KeyValuePair> uefvs = netCDF.getUniqueFactorValues();
-        assert (uVals.size() >= uefvs.size());
+        assertTrue(uVals.size() >= uefvs.size());
 
         for (KeyValuePair uefv : uVals) {
             if (uniques.contains(uefv)) {


### PR DESCRIPTION
Added non-filtered `getUVals` as a temporary solution; as far as I can see, the `PVAL` and `TSTAT` structures are still parallel to `uVAL`, so that should be enough for a quick relief.

For the next step, we must either get rid of or encapsulate the parallel structures we use.
