### PR TITLE
Trac3154

### DIFF
--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Property.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Property.java
@@ -27,7 +27,7 @@ public final class Property {
 
     public Property(Long id, String name) {
         this.propertyid = id;
-        this.name = name;
+        this.name = name.toLowerCase();
     }
 
     public Long getId() {


### PR DESCRIPTION
[Ticket 3154](http://bar.ebi.ac.uk:8080/trac/ticket/3154) — hot fix to prevent UQ_PROPERTY_NAME constraint vlolation exception. A more complete solution to this issue will be implemented in develop as part of [Ticket 2849](http://bar.ebi.ac.uk:8080/trac/ticket/2849)
