### PR TITLE
Trac 3120 - TRANSACTIONAL instead of NONSTRICT_READ_WRITE

### DIFF
--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/ArrayDesign.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/ArrayDesign.java
@@ -31,7 +31,7 @@ import java.util.*;
 import static java.util.Collections.singletonList;
 
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class ArrayDesign {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "arrayDesignSeq")

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Assay.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Assay.java
@@ -40,7 +40,7 @@ import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Sets.newTreeSet;
 
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class Assay {
     private static final Function<AssayProperty, String> PROPERTY_NAME =
             new Function<AssayProperty, String>() {
@@ -89,7 +89,7 @@ public class Assay {
     @OneToMany(targetEntity = AssayProperty.class, mappedBy = "assay",
             orphanRemoval = true, cascade = CascadeType.ALL)
     @Fetch(FetchMode.SUBSELECT)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
     private List<AssayProperty> properties = new ArrayList<AssayProperty>();
 
     Assay() {

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/AssayProperty.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/AssayProperty.java
@@ -39,7 +39,7 @@ import static java.util.Collections.unmodifiableList;
 
 @Entity
 @Table(name = "A2_ASSAYPV")
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public final class AssayProperty {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "assayPVSeq")

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Asset.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Asset.java
@@ -35,7 +35,7 @@ import javax.persistence.*;
  */
 @Entity
 @Table(name = "A2_EXPERIMENTASSET")
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class Asset {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "assetSeq")

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
@@ -39,7 +39,7 @@ import static com.google.common.collect.Sets.newTreeSet;
 import static uk.ac.ebi.gxa.utils.DateUtil.copyOf;
 
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class Experiment {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "experimentSeq")
@@ -62,12 +62,12 @@ public class Experiment {
     private List<Asset> assets = new ArrayList<Asset>();
 
     @OneToMany(targetEntity = Assay.class, mappedBy = "experiment", orphanRemoval = true, cascade = CascadeType.ALL)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
     @Fetch(FetchMode.SUBSELECT)
     private List<Assay> assays = new ArrayList<Assay>();
 
     @OneToMany(targetEntity = Sample.class, mappedBy = "experiment", orphanRemoval = true, cascade = CascadeType.ALL)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
     @Fetch(FetchMode.SUBSELECT)
     private List<Sample> samples = new ArrayList<Sample>();
 

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Ontology.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Ontology.java
@@ -6,7 +6,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import javax.persistence.*;
 
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class Ontology {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ontologySeq")

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/OntologyTerm.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/OntologyTerm.java
@@ -7,7 +7,7 @@ import uk.ac.ebi.gxa.Temporary;
 import javax.persistence.*;
 
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class OntologyTerm {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ontologyTermSeq")

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Property.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Property.java
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public final class Property {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "propertySeq")
@@ -19,7 +19,7 @@ public final class Property {
     private String name;
     @OneToMany(targetEntity = PropertyValue.class, mappedBy = "property", orphanRemoval = true)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
     private List<PropertyValue> values = new ArrayList<PropertyValue>();
 
     Property() {

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/PropertyValue.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/PropertyValue.java
@@ -7,7 +7,7 @@ import org.hibernate.annotations.Immutable;
 import javax.persistence.*;
 
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 @Immutable
 public final class PropertyValue {
     @Id

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Sample.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Sample.java
@@ -45,7 +45,7 @@ import static com.google.common.collect.Collections2.transform;
 import static com.google.common.collect.Sets.newTreeSet;
 
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class Sample {
     public static final Logger log = LoggerFactory.getLogger(Sample.class);
 
@@ -67,7 +67,7 @@ public class Sample {
             orphanRemoval = true)
     @Fetch(FetchMode.SUBSELECT)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
     private List<SampleProperty> properties = new ArrayList<SampleProperty>();
 
     Sample() {

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/SampleProperty.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/SampleProperty.java
@@ -41,7 +41,7 @@ import static java.util.Collections.unmodifiableList;
 
 @Entity
 @Table(name = "A2_SAMPLEPV")
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public final class SampleProperty {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "samplePVSeq")

--- a/pom.xml
+++ b/pom.xml
@@ -464,10 +464,6 @@
             <id>hasbanana</id>
             <url>http://www.hasbanana.com/maven/repo</url>
         </repository>
-        <repository>
-            <id>opencast</id>
-            <url>http://repository.opencastproject.org/nexus/content/groups/public</url>
-        </repository>
     </repositories>
 
     <distributionManagement>


### PR DESCRIPTION
In the `develop` branch, replace all the `NONSTRICT_READ_WRITE` cache directives with `TRANSACTIONAL`, test performance, and unless it shows a significant slowdown, leave it on a safer side.

http://bar.ebi.ac.uk:8080/trac/ticket/3120

So far no impact noticed. Please let me know in case of any problems.
