### PR TITLE
Trac 3177 DataIntegrityViolationException when loading experiments on lime

### DIFF
--- a/atlas-loader/src/main/java/uk/ac/ebi/gxa/loader/dao/LoaderDAO.java
+++ b/atlas-loader/src/main/java/uk/ac/ebi/gxa/loader/dao/LoaderDAO.java
@@ -38,7 +38,7 @@ public class LoaderDAO {
         // TODO: 4alf: track newly-created values
         Property property = propertyDAO.getByName(name);
         if (property == null) {
-            propertyDAO.save(property = new Property(null, name));
+            propertyDAO.save(property = new Property(null, name.toLowerCase()));
         }
         PropertyValue propertyValue = propertyValueDAO.find(property, value);
         if (propertyValue == null) {


### PR DESCRIPTION
Ticket http://bar.ebi.ac.uk:8080/trac/ticket/3177

We checked with `.toLowerCase()` and saved without. Fixed. `develop` branch will be addressed as part of http://bar.ebi.ac.uk:8080/trac/ticket/2849
