### PR TITLE
Unnecessary Oracle dependencies

### DIFF
--- a/atlas-test/pom.xml
+++ b/atlas-test/pom.xml
@@ -81,11 +81,6 @@
             <artifactId>commons-dbcp</artifactId>
             <version>1.2.2</version>
         </dependency>
-        <dependency>
-            <groupId>com.oracle</groupId>
-            <artifactId>ojdbc6</artifactId>
-            <version>11.2.0.3.0</version>
-        </dependency>
 
         <!-- servlet api req'd for SOLR -->
         <dependency>

--- a/atlas-web/pom.xml
+++ b/atlas-web/pom.xml
@@ -365,12 +365,6 @@
             <type>test-jar</type>
             <version>2.0.10-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>com.oracle</groupId>
-            <artifactId>ojdbc6</artifactId>
-            <version>11.2.0.3.0</version>
-            <scope>test</scope>
-        </dependency>
 
         <!-- logging dependencies -->
 


### PR DESCRIPTION
dropping the unnecessary Oracle dependencies, leaving only one in biocep tests
