### PR TITLE
Addressing `A2_SCHEMAVERSION` export problem

### DIFF
--- a/sql/create_ctl_for_table.sql
+++ b/sql/create_ctl_for_table.sql
@@ -12,6 +12,7 @@ set verify off
 SELECT  'OPTIONS(DIRECT=TRUE,ROWS=1000000) LOAD DATA TRUNCATE INTO TABLE ' || upper('A2_&1') ||
         ' FIELDS TERMINATED BY ''\t''' ||
         ' TRAILING NULLCOLS (' || WM_CONCAT(Column_Name ||
-          Decode(Data_Type, 'VARCHAR2', ' CHAR(' || data_length || ')', 'DATE', ' DATE "YYYY-MM-DD HH24:MI:SS"' )) || ')'
+          Decode(Data_Type, 'VARCHAR2', ' CHAR(' || data_length || ')', 'DATE', ' DATE "YYYY-MM-DD HH24:MI:SS"',
+           'TIMESTAMP(6)', ' TIMESTAMP "YYYY-MM-DD HH24:MI:SS"')) || ')'
 FROM user_tab_columns WHERE table_name=upper('A2_&1');
 exit;

--- a/sql/create_ctl_for_table.sql
+++ b/sql/create_ctl_for_table.sql
@@ -12,7 +12,9 @@ set verify off
 SELECT  'OPTIONS(DIRECT=TRUE,ROWS=1000000) LOAD DATA TRUNCATE INTO TABLE ' || upper('A2_&1') ||
         ' FIELDS TERMINATED BY ''\t''' ||
         ' TRAILING NULLCOLS (' || WM_CONCAT(Column_Name ||
-          Decode(Data_Type, 'VARCHAR2', ' CHAR(' || data_length || ')', 'DATE', ' DATE "YYYY-MM-DD HH24:MI:SS"',
-           'TIMESTAMP(6)', ' TIMESTAMP "YYYY-MM-DD HH24:MI:SS"')) || ')'
+          Decode(Data_Type,
+                 'VARCHAR2',     ' CHAR(' || data_length || ')',
+                 'DATE',         ' DATE "YYYY-MM-DD HH24:MI:SS"',
+                 'TIMESTAMP(6)', ' TIMESTAMP "YYYY-MM-DD HH24:MI:SS"')) || ')'
 FROM user_tab_columns WHERE table_name=upper('A2_&1');
 exit;

--- a/sql/create_ctl_for_table.sql
+++ b/sql/create_ctl_for_table.sql
@@ -15,6 +15,6 @@ SELECT  'OPTIONS(DIRECT=TRUE,ROWS=1000000) LOAD DATA TRUNCATE INTO TABLE ' || up
           Decode(Data_Type,
                  'VARCHAR2',     ' CHAR(' || data_length || ')',
                  'DATE',         ' DATE "YYYY-MM-DD HH24:MI:SS"',
-                 'TIMESTAMP(6)', ' TIMESTAMP "YYYY-MM-DD HH24:MI:SS"')) || ')'
+                 'TIMESTAMP(6)', ' TIMESTAMP "YYYY-MM-DD HH24:MI:SS.FF"')) || ')'
 FROM user_tab_columns WHERE table_name=upper('A2_&1');
 exit;

--- a/sql/create_sql_for_table.sql
+++ b/sql/create_sql_for_table.sql
@@ -12,7 +12,7 @@ set verify off
 SELECT 'SELECT ' || WM_CONCAT(
   DECODE(data_type,
          'DATE',         'TO_CHAR(' || column_name || ',''YYYY-MM-DD HH24:MI:SS'')',
-         'TIMESTAMP(6)', 'TO_CHAR(' || column_name || ',''YYYY-MM-DD HH24:MI:SS'')',
+         'TIMESTAMP(6)', 'TO_CHAR(' || column_name || ',''YYYY-MM-DD HH24:MI:SS.FF'')',
          'VARCHAR2',     ' DECODE(' || column_name || ', null, ' || column_name || ','
                                     || ' REPLACE(' || column_name ||', chr(10), chr(32)))',
          column_name))

--- a/sql/create_sql_for_table.sql
+++ b/sql/create_sql_for_table.sql
@@ -10,10 +10,12 @@ set feedback off
 set verify off
 
 SELECT 'SELECT ' || WM_CONCAT(
-  DECODE(data_type, 'DATE', 'TO_CHAR(' || column_name || ',''YYYY-MM-DD HH24:MI:SS'')',
+  DECODE(data_type,
+         'DATE',         'TO_CHAR(' || column_name || ',''YYYY-MM-DD HH24:MI:SS'')',
          'TIMESTAMP(6)', 'TO_CHAR(' || column_name || ',''YYYY-MM-DD HH24:MI:SS'')',
-         DECODE(data_type, 'VARCHAR2',
-                  ' DECODE(' || column_name || ', null, ' || column_name || ', REPLACE(' || column_name ||', chr(10), chr(32)))', column_name)))
+         'VARCHAR2',     ' DECODE(' || column_name || ', null, ' || column_name || ','
+                                    || ' REPLACE(' || column_name ||', chr(10), chr(32)))',
+         column_name))
  || ' FROM ' || UPPER('A2_&1')
 FROM user_tab_columns WHERE table_name=UPPER('A2_&1');
 exit;

--- a/sql/create_sql_for_table.sql
+++ b/sql/create_sql_for_table.sql
@@ -13,7 +13,7 @@ SELECT 'SELECT ' || WM_CONCAT(
   DECODE(data_type,
          'DATE',         'TO_CHAR(' || column_name || ',''YYYY-MM-DD HH24:MI:SS'')',
          'TIMESTAMP(6)', 'TO_CHAR(' || column_name || ',''YYYY-MM-DD HH24:MI:SS.FF'')',
-         'VARCHAR2',     ' DECODE(' || column_name || ', null, ' || column_name || ','
+         'VARCHAR2',     'DECODE(' || column_name || ', null, ' || column_name || ','
                                     || ' REPLACE(' || column_name ||', chr(10), chr(32)))',
          column_name))
  || ' FROM ' || UPPER('A2_&1')

--- a/sql/create_sql_for_table.sql
+++ b/sql/create_sql_for_table.sql
@@ -11,6 +11,7 @@ set verify off
 
 SELECT 'SELECT ' || WM_CONCAT(
   DECODE(data_type, 'DATE', 'TO_CHAR(' || column_name || ',''YYYY-MM-DD HH24:MI:SS'')',
+         'TIMESTAMP(6)', 'TO_CHAR(' || column_name || ',''YYYY-MM-DD HH24:MI:SS'')',
          DECODE(data_type, 'VARCHAR2',
                   ' DECODE(' || column_name || ', null, ' || column_name || ', REPLACE(' || column_name ||', chr(10), chr(32)))', column_name)))
  || ' FROM ' || UPPER('A2_&1')


### PR DESCRIPTION
Added support for `TIMESTAMP(6)`—ugly, but works. It would be good to review these scripts: since we host `flat_array.pc` anyway, we can as well change it to support data translation for us.
