### PR TITLE
trac3217: Tooltips broken on experiment page after moving to wro4j bundles

### DIFF
--- a/atlas-web/src/main/webapp/WEB-INF/jsp/experimentpage/experiment.jsp
+++ b/atlas-web/src/main/webapp/WEB-INF/jsp/experimentpage/experiment.jsp
@@ -271,7 +271,7 @@
 </script>
 
 <script id="geneToolTipTemplate" type="text/x-jquery-tmpl">
-    <div class="gtooltip">
+    <div>
       <div class="genename">
         <b>\${name}</b> \${identifiers}
        </div>

--- a/atlas-web/src/main/webapp/WEB-INF/jsp/query/query-result.jsp
+++ b/atlas-web/src/main/webapp/WEB-INF/jsp/query/query-result.jsp
@@ -140,6 +140,8 @@
                 var td  = $(this).parents("td:first");
                 return $('.gtooltip', td).html();
             },
+            extraClass: "tooltip",
+            id: "tooltip-over-results",
             showURL: false
         });
 

--- a/atlas-web/src/main/webapp/atlas.css
+++ b/atlas-web/src/main/webapp/atlas.css
@@ -272,8 +272,38 @@ padding: 0;
     text-decoration: underline;
 }
 
-/* unsorted */
+/* tooltips */
 
+.tooltip {
+    position: absolute;
+    z-index: 3001;
+    padding: 10px;
+    max-width: 800px;
+    border: 1px solid #5E9E9E;
+    background-color: #EEF5F5;
+}
+
+.tooltip em {
+    font: inherit;
+    background-color: yellow;
+    text-decoration: inherit;
+}
+
+.tooltip .genename {
+    margin-bottom: 10px;
+    font-size: 10px;
+}
+
+.tooltip .genename b {
+    font-weight: bold;
+    font-size: 14px;
+}
+
+.tooltip div {
+    margin-bottom: 5px;
+}
+
+/* unsorted */
 
 .nowrap {
     white-space: nowrap;

--- a/atlas-web/src/main/webapp/scripts/experiment.js
+++ b/atlas-web/src/main/webapp/scripts/experiment.js
@@ -1799,6 +1799,8 @@
                 bodyHandler: function () {
                     return $("#geneToolTipTemplate").tmpl(toolTips[this.text]);
                 },
+                id: "tooltip-over-grid",
+                extraClass: "tooltip",
                 showURL: false
             });
 
@@ -1807,6 +1809,8 @@
                 bodyHandler: function () {
                     return "View in the Ensembl Genome Browser (new window)";
                 },
+                id: "tooltip-over-grid",
+                extraClass: "tooltip",
                 showURL: false
             });
         }

--- a/atlas-web/src/main/webapp/structured-query.css
+++ b/atlas-web/src/main/webapp/structured-query.css
@@ -33,7 +33,7 @@
 }
 
 /* basic colors */
-#expopup, #expopup .exptable, #tooltip, .waiter {
+#expopup, #expopup .exptable, .waiter {
     border: 1px solid #5E9E9E
 }
 
@@ -41,7 +41,7 @@ fieldset, #drill {
     border: none
 }
 
-#squery th, #tooltip, #expopup, .diaghead {
+#squery th, #expopup, .diaghead {
     background-color: #EEF5F5;
 }
 
@@ -120,7 +120,7 @@ fieldset, #drill {
 
 #squery td.genename { font-size: 12px; font-weight: bold; }
 
-#squery em, #tooltip em { font: inherit; background-color: yellow;text-decoration:inherit;  }
+#squery em { font: inherit; background-color: yellow;text-decoration:inherit;  }
 
 #squery .downback, .downback {
     background: #0000ff;
@@ -334,17 +334,6 @@ fieldset, #drill {
 
 #tooltipPlot .genename { margin-bottom: 10px;font-size:10px; }
 #tooltipPlot .genename b { font-weight: bold; font-size: 14px; }
-
-#tooltip {
-	position: absolute;
-	z-index: 3000;
-    padding: 10px;
-    max-width:800px;
-}
-#tooltip div { margin-bottom: 5px; }
-
-#tooltip .genename { margin-bottom: 10px;font-size:10px; }
-#tooltip .genename b { font-weight: bold; font-size: 14px; }
 
 .plot { position: relative; width: 240px; height: 100px; }
 


### PR DESCRIPTION
(http://bar.ebi.ac.uk:8080/trac/ticket/3217)

The tooltip styles moved to atlas.css..

@alf239, @rpetry - please review
