### PR TITLE
Ticket #2911 - 1. Enabled searching by gene ensfamily_description propert

### DIFF
--- a/atlas-web/src/main/java/ae3/dao/GeneSolrDAO.java
+++ b/atlas-web/src/main/java/ae3/dao/GeneSolrDAO.java
@@ -180,7 +180,7 @@ public class GeneSolrDAO {
         if (ids.isEmpty()) return Collections.emptyList();
 
         StringBuilder sb = new StringBuilder();
-        for (Object id : ids) {
+        for (String id : ids) {
             sb.append(" id:").append(id).append(" identifier:").append(id);
             for (String idprop : additionalIds)
                 sb.append(" property_").append(idprop).append(":").append(id);

--- a/atlas-web/src/main/java/ae3/dao/GeneSolrDAO.java
+++ b/atlas-web/src/main/java/ae3/dao/GeneSolrDAO.java
@@ -47,10 +47,9 @@ import static uk.ac.ebi.gxa.exceptions.LogUtil.createUnexpected;
  * @author ostolop, mdylag, pashky
  */
 public class GeneSolrDAO {
+    private static final Logger log = LoggerFactory.getLogger(GeneSolrDAO.class);
 
     private AtlasProperties atlasProperties;
-
-    private static final Logger log = LoggerFactory.getLogger(GeneSolrDAO.class);
 
     private SolrServer geneSolr;
 

--- a/atlas-web/src/main/java/ae3/dao/GeneSolrDAO.java
+++ b/atlas-web/src/main/java/ae3/dao/GeneSolrDAO.java
@@ -34,6 +34,7 @@ import org.apache.solr.common.SolrDocumentList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.ebi.gxa.exceptions.LogUtil;
+import uk.ac.ebi.gxa.properties.AtlasProperties;
 import uk.ac.ebi.gxa.utils.EscapeUtil;
 
 import java.util.*;
@@ -46,12 +47,19 @@ import static uk.ac.ebi.gxa.exceptions.LogUtil.createUnexpected;
  * @author ostolop, mdylag, pashky
  */
 public class GeneSolrDAO {
+
+    private AtlasProperties atlasProperties;
+
     private static final Logger log = LoggerFactory.getLogger(GeneSolrDAO.class);
 
     private SolrServer geneSolr;
 
     public void setGeneSolr(SolrServer geneSolr) {
         this.geneSolr = geneSolr;
+    }
+
+    public void setAtlasProperties(AtlasProperties atlasProperties) {
+        this.atlasProperties = atlasProperties;
     }
 
     /**
@@ -169,7 +177,7 @@ public class GeneSolrDAO {
      * @param additionalIds additional properties to search for
      * @return Iterable<AtlasGene>
      */
-    public Iterable<AtlasGene> getGenesByAnyIdentifiers(Collection ids, List<String> additionalIds) {
+    private Iterable<AtlasGene> getGenesByAnyIdentifiers(Collection ids, List<String> additionalIds) {
         if (ids.isEmpty()) return Collections.emptyList();
 
         StringBuilder sb = new StringBuilder();
@@ -191,7 +199,6 @@ public class GeneSolrDAO {
     public Iterable<AtlasGene> getGenesByIdentifiers(Collection ids) {
         return getGenesByAnyIdentifiers(ids, Collections.<String>emptyList());
     }
-
 
     /**
      * @param name name of genes to search for
@@ -293,14 +300,14 @@ public class GeneSolrDAO {
         return result;
     }
 
-    public List<Long> findGeneIds(Collection<String> query, List<String> additionalIds) {
+    public List<Long> findGeneIds(Collection<String> query) {
         List<Long> genes = Lists.newArrayList();
 
         for (String text : query) {
             if (Strings.isNullOrEmpty(text)) {
                 continue;
             }
-            Iterator<AtlasGene> res = getGenesByAnyIdentifiers(Collections.singleton(text), additionalIds).iterator();
+            Iterator<AtlasGene> res = getGenesByAnyIdentifiers(Collections.singleton(text), atlasProperties.getGeneAutocompleteIdFields()).iterator();
             if (!res.hasNext()) {
                 for (AtlasGene gene : getGenesByName(text)) {
                     genes.add((long) gene.getGeneId());

--- a/atlas-web/src/main/java/ae3/dao/GeneSolrDAO.java
+++ b/atlas-web/src/main/java/ae3/dao/GeneSolrDAO.java
@@ -177,7 +177,7 @@ public class GeneSolrDAO {
      * @param additionalIds additional properties to search for
      * @return Iterable<AtlasGene>
      */
-    private Iterable<AtlasGene> getGenesByAnyIdentifiers(Collection ids, List<String> additionalIds) {
+    private Iterable<AtlasGene> getGenesByAnyIdentifiers(Collection<String> ids, List<String> additionalIds) {
         if (ids.isEmpty()) return Collections.emptyList();
 
         StringBuilder sb = new StringBuilder();
@@ -196,7 +196,7 @@ public class GeneSolrDAO {
      * @param ids Collection of ids
      * @return Iterable<AtlasGene>
      */
-    public Iterable<AtlasGene> getGenesByIdentifiers(Collection ids) {
+    public Iterable<AtlasGene> getGenesByIdentifiers(Collection<String> ids) {
         return getGenesByAnyIdentifiers(ids, Collections.<String>emptyList());
     }
 

--- a/atlas-web/src/main/java/ae3/service/experiment/AtlasExperimentAnalyticsViewService.java
+++ b/atlas-web/src/main/java/ae3/service/experiment/AtlasExperimentAnalyticsViewService.java
@@ -13,6 +13,7 @@ import uk.ac.ebi.gxa.analytics.compute.ComputeException;
 import uk.ac.ebi.gxa.data.ExperimentPart;
 import uk.ac.ebi.gxa.data.ExperimentPartCriteria;
 import uk.ac.ebi.gxa.data.ExperimentWithData;
+import uk.ac.ebi.gxa.properties.AtlasProperties;
 import uk.ac.ebi.microarray.atlas.model.UpDownCondition;
 
 import javax.annotation.Nonnull;
@@ -31,6 +32,7 @@ import static uk.ac.ebi.microarray.atlas.model.UpDownCondition.*;
 
 public class AtlasExperimentAnalyticsViewService {
 
+    private AtlasProperties atlasProperties;
     private static final BestDesignElementsResult EMPTY_DESIGN_ELEMENT_RESULT = new BestDesignElementsResult();
     private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -43,6 +45,10 @@ public class AtlasExperimentAnalyticsViewService {
         upDownConditionInR.put(CONDITION_DOWN, "DOWN");
         upDownConditionInR.put(CONDITION_NONDE, "NON_D_E");
         upDownConditionInR.put(CONDITION_ANY, "ANY");
+    }
+
+    public void setAtlasProperties(AtlasProperties atlasProperties) {
+        this.atlasProperties = atlasProperties;
     }
 
     private GeneSolrDAO geneSolrDAO;
@@ -91,7 +97,7 @@ public class AtlasExperimentAnalyticsViewService {
         final boolean genesSpecified = !geneIdentifierQuery.isEmpty();
 
         final List<Long> geneIds = genesSpecified
-                ? geneSolrDAO.findGeneIds(geneIdentifierQuery)
+                ? geneSolrDAO.findGeneIds(geneIdentifierQuery, atlasProperties.getGeneAutocompleteIdFields())
                 : Collections.<Long>emptyList();
         if (genesSpecified && geneIds.isEmpty()) {
             return EMPTY_DESIGN_ELEMENT_RESULT;

--- a/atlas-web/src/main/java/ae3/service/experiment/AtlasExperimentAnalyticsViewService.java
+++ b/atlas-web/src/main/java/ae3/service/experiment/AtlasExperimentAnalyticsViewService.java
@@ -13,7 +13,6 @@ import uk.ac.ebi.gxa.analytics.compute.ComputeException;
 import uk.ac.ebi.gxa.data.ExperimentPart;
 import uk.ac.ebi.gxa.data.ExperimentPartCriteria;
 import uk.ac.ebi.gxa.data.ExperimentWithData;
-import uk.ac.ebi.gxa.properties.AtlasProperties;
 import uk.ac.ebi.microarray.atlas.model.UpDownCondition;
 
 import javax.annotation.Nonnull;
@@ -32,7 +31,6 @@ import static uk.ac.ebi.microarray.atlas.model.UpDownCondition.*;
 
 public class AtlasExperimentAnalyticsViewService {
 
-    private AtlasProperties atlasProperties;
     private static final BestDesignElementsResult EMPTY_DESIGN_ELEMENT_RESULT = new BestDesignElementsResult();
     private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -45,10 +43,6 @@ public class AtlasExperimentAnalyticsViewService {
         upDownConditionInR.put(CONDITION_DOWN, "DOWN");
         upDownConditionInR.put(CONDITION_NONDE, "NON_D_E");
         upDownConditionInR.put(CONDITION_ANY, "ANY");
-    }
-
-    public void setAtlasProperties(AtlasProperties atlasProperties) {
-        this.atlasProperties = atlasProperties;
     }
 
     private GeneSolrDAO geneSolrDAO;
@@ -97,7 +91,7 @@ public class AtlasExperimentAnalyticsViewService {
         final boolean genesSpecified = !geneIdentifierQuery.isEmpty();
 
         final List<Long> geneIds = genesSpecified
-                ? geneSolrDAO.findGeneIds(geneIdentifierQuery, atlasProperties.getGeneAutocompleteIdFields())
+                ? geneSolrDAO.findGeneIds(geneIdentifierQuery)
                 : Collections.<Long>emptyList();
         if (genesSpecified && geneIds.isEmpty()) {
             return EMPTY_DESIGN_ELEMENT_RESULT;

--- a/atlas-web/src/main/java/ae3/service/experiment/AtlasExperimentAnalyticsViewService.java
+++ b/atlas-web/src/main/java/ae3/service/experiment/AtlasExperimentAnalyticsViewService.java
@@ -5,6 +5,8 @@ import ae3.model.AtlasGene;
 import ae3.service.experiment.rcommand.RCommand;
 import ae3.service.experiment.rcommand.RCommandResult;
 import ae3.service.experiment.rcommand.RCommandStatement;
+import com.google.common.base.Functions;
+import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -152,7 +154,7 @@ public class AtlasExperimentAnalyticsViewService {
             result.setTotalSize(total);
 
             Map<Integer, AtlasGene> geneMap = new HashMap<Integer, AtlasGene>();
-            Iterable<AtlasGene> solrGenes = geneSolrDAO.getGenesByIdentifiers(Ints.asList(gIds));
+            Iterable<AtlasGene> solrGenes = geneSolrDAO.getGenesByIdentifiers(Lists.transform(Ints.asList(gIds), Functions.toStringFunction()));
             for (AtlasGene gene : solrGenes) {
                 geneMap.put(gene.getGeneId(), gene);
             }

--- a/atlas-web/src/main/resources/atlas.properties
+++ b/atlas-web/src/main/resources/atlas.properties
@@ -82,7 +82,7 @@ atlas.gene.list.autogenerate.afterindex=false
 atlas.dasbase=http://www.ebi.ac.uk/gxa
 atlas.dasfactors=organism_part,disease_state,cell_type,cell_line,compound,developmental_stage,infect,phenotype
 
-atlas.gene.autocomplete.ids=dbxref,embl,ensfamily,ensgene,ensprotein,enstranscript,go,image,interpro,locuslink,omim,orf,refseq,unigene,uniprot,hmdb,chebi,cas,uniprometenz,designelement,mgi_id,genesigdb
+atlas.gene.autocomplete.ids=dbxref,embl,ensfamily,ensfamily_description,ensgene,ensprotein,enstranscript,go,image,interpro,locuslink,omim,orf,refseq,unigene,uniprot,hmdb,chebi,cas,uniprometenz,designelement,mgi_id,genesigdb
 atlas.gene.autocomplete.ids.limit=3
 atlas.gene.autocomplete.names=synonym
 atlas.gene.autocomplete.names.limit=7

--- a/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
+++ b/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
@@ -244,6 +244,7 @@ http://www.springframework.org/schema/util/spring-util.xsd">
     <bean name="atlasExperimentAnalyticsViewService" class="ae3.service.experiment.AtlasExperimentAnalyticsViewService">
         <property name="geneSolrDAO" ref="geneSolrDAO"/>
         <property name="computeService" ref="atlasComputeService"/>
+        <property name="atlasProperties" ref="atlasProperties"/>
     </bean>
 
     <bean name="atlasStatisticsQueryService" class="ae3.service.AtlasBitIndexQueryService">

--- a/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
+++ b/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
@@ -210,6 +210,7 @@ http://www.springframework.org/schema/util/spring-util.xsd">
 
     <bean name="geneSolrDAO" class="ae3.dao.GeneSolrDAO">
         <property name="geneSolr" ref="solrServerAtlas"/>
+        <property name="atlasProperties" ref="atlasProperties"/>
     </bean>
 
     <bean name="experimentSolrDAO" class="ae3.dao.ExperimentSolrDAO">
@@ -244,7 +245,6 @@ http://www.springframework.org/schema/util/spring-util.xsd">
     <bean name="atlasExperimentAnalyticsViewService" class="ae3.service.experiment.AtlasExperimentAnalyticsViewService">
         <property name="geneSolrDAO" ref="geneSolrDAO"/>
         <property name="computeService" ref="atlasComputeService"/>
-        <property name="atlasProperties" ref="atlasProperties"/>
     </bean>
 
     <bean name="atlasStatisticsQueryService" class="ae3.service.AtlasBitIndexQueryService">


### PR DESCRIPTION
Ticket #2911 - 1. Enabled searching by gene ensfamily_description property in Atlas. 2. In expression table on experiment page: enable retrieval of many genes by their identifiers, name or properties (previously the first gene was retrieved by identifier; or failing that - a list of genes from 'by name' search)

@olgamelnichuk, @alf239 - could you review please
