### PR TITLE
Adjusted the approach to finding out the path to resources

### DIFF
--- a/atlas-analytics/src/test/java/uk/ac/ebi/gxa/analytics/generator/TestExperimentAnalyticsGeneratorService.java
+++ b/atlas-analytics/src/test/java/uk/ac/ebi/gxa/analytics/generator/TestExperimentAnalyticsGeneratorService.java
@@ -31,8 +31,8 @@ import uk.ac.ebi.gxa.analytics.generator.listener.AnalyticsGeneratorListener;
 import uk.ac.ebi.gxa.analytics.generator.service.ExperimentAnalyticsGeneratorService;
 import uk.ac.ebi.gxa.dao.AtlasDAOTestCase;
 import uk.ac.ebi.gxa.data.AtlasDataDAO;
+import uk.ac.ebi.gxa.utils.ResourceUtil;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.ExecutorService;
@@ -53,7 +53,7 @@ public class TestExperimentAnalyticsGeneratorService extends AtlasDAOTestCase {
     @Test
     public void testCreateAnalyticsForExperimentWithoutFactors() throws Exception {
         final AtlasDataDAO atlasDataDAO = new AtlasDataDAO();
-        atlasDataDAO.setAtlasDataRepo(new File(getClass().getClassLoader().getResource("").getPath()));
+        atlasDataDAO.setAtlasDataRepo(ResourceUtil.getResourceRoot(getClass()));
 
         final AtlasComputeService atlasComputeService = createMock(AtlasComputeService.class);
         expect(atlasComputeService

--- a/atlas-data-storage/src/test/java/uk/ac/ebi/gxa/data/TestAtlasDataDAO.java
+++ b/atlas-data-storage/src/test/java/uk/ac/ebi/gxa/data/TestAtlasDataDAO.java
@@ -1,12 +1,12 @@
 package uk.ac.ebi.gxa.data;
 
 import junit.framework.TestCase;
+import uk.ac.ebi.gxa.utils.ResourceUtil;
 import uk.ac.ebi.microarray.atlas.model.ArrayDesign;
 import uk.ac.ebi.microarray.atlas.model.Assay;
 import uk.ac.ebi.microarray.atlas.model.Experiment;
 import uk.ac.ebi.microarray.atlas.model.ExpressionAnalysis;
 
-import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.*;
@@ -47,7 +47,7 @@ public class TestAtlasDataDAO extends TestCase {
         experiment.setAssays(Collections.singletonList(assay));
 
         atlasDataDAO = new AtlasDataDAO();
-        atlasDataDAO.setAtlasDataRepo(new File(getClass().getClassLoader().getResource("").getPath()));
+        atlasDataDAO.setAtlasDataRepo(ResourceUtil.getResourceRoot(getClass()));
 
         geneIds = new HashSet<Long>();
         geneIds.add(geneId);

--- a/atlas-data-storage/src/test/java/uk/ac/ebi/gxa/data/TestNetCDFSplitting.java
+++ b/atlas-data-storage/src/test/java/uk/ac/ebi/gxa/data/TestNetCDFSplitting.java
@@ -27,6 +27,7 @@ import junit.framework.TestCase;
 import ucar.ma2.ArrayChar;
 import ucar.nc2.NetcdfFile;
 import uk.ac.ebi.gxa.utils.FileUtil;
+import uk.ac.ebi.gxa.utils.ResourceUtil;
 import uk.ac.ebi.microarray.atlas.model.*;
 
 import java.io.File;
@@ -47,7 +48,7 @@ public class TestNetCDFSplitting extends TestCase {
     @Override
     protected void setUp() throws Exception {
         atlasDataDAO = new AtlasDataDAO();
-        File baseDirectory = new File(getClass().getClassLoader().getResource("").getPath());
+        File baseDirectory = ResourceUtil.getResourceRoot(getClass());
         tempDirectory = FileUtil.createTempDirectory("atlas-test");
         baseExperimentDirectory = new File(baseDirectory.getAbsolutePath() + "/MTAB/00/E-MTAB-25");
         experimentDirectory = new File(tempDirectory.getAbsolutePath() + "/MTAB/00/E-MTAB-25");

--- a/atlas-loader/src/test/java/uk/ac/ebi/gxa/loader/TestAtlasMAGETABLoader.java
+++ b/atlas-loader/src/test/java/uk/ac/ebi/gxa/loader/TestAtlasMAGETABLoader.java
@@ -65,8 +65,7 @@ public class TestAtlasMAGETABLoader extends AtlasDAOTestCase {
         super.setUp();
 
         cache = new AtlasLoadCache();
-        parseURL = this.getClass().getClassLoader().getResource(
-                "E-GEOD-3790.idf.txt");
+        parseURL = this.getClass().getClassLoader().getResource("E-GEOD-3790.idf.txt");
     }
 
     public void tearDown() throws Exception {

--- a/atlas-test/src/test/java/uk/ac/ebi/gxa/AbstractIndexDataTestCase.java
+++ b/atlas-test/src/test/java/uk/ac/ebi/gxa/AbstractIndexDataTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2010 Microarray Informatics Team, EMBL-European Bioinformatics Institute
+ * Copyright 2008-2011 Microarray Informatics Team, EMBL-European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import uk.ac.ebi.gxa.index.builder.service.GeneAtlasIndexBuilderService;
 import uk.ac.ebi.gxa.properties.AtlasProperties;
 import uk.ac.ebi.gxa.properties.ResourceFileStorage;
 import uk.ac.ebi.gxa.utils.FileUtil;
+import uk.ac.ebi.gxa.utils.ResourceUtil;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
@@ -80,7 +81,7 @@ public abstract class AbstractIndexDataTestCase extends AtlasDAOTestCase {
 
         buildSolrIndexes();
 
-        final File classPath = new File(this.getClass().getClassLoader().getResource("").getPath());
+        final File classPath = ResourceUtil.getResourceRoot(getClass());
         atlasDataDAO = new AtlasDataDAO();
         atlasDataDAO.setAtlasDataRepo(new File(classPath, "netcdfs"));
     }

--- a/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/ResourceUtil.java
+++ b/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/ResourceUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2008-2011 Microarray Informatics Team, EMBL-European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * For further details of the Gene Expression Atlas project, including source code,
+ * downloads and documentation, please see:
+ *
+ * http://gxa.github.com/gxa
+ */
+
+package uk.ac.ebi.gxa.utils;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static uk.ac.ebi.gxa.exceptions.LogUtil.createUnexpected;
+
+/**
+ * @author alf
+ */
+public final class ResourceUtil {
+
+    private ResourceUtil() {
+    }
+
+    public static File getResourceRoot(Class clazz) {
+        try {
+            final String classResource = getClassResource(clazz).toString();
+            final String root = classResource.substring(0, classResource.length() - clazz.getName().length() - ".class".length());
+            return new File(new URL(root).getPath()); // Drop "file://" if present
+        } catch (MalformedURLException e) {
+            throw createUnexpected("Non-supported class loader", e);
+        }
+    }
+
+    public static URL getClassResource(Class clazz) {
+        return clazz.getClassLoader().getResource(clazz.getName().replace('.', '/') + ".class");
+    }
+}

--- a/atlas-web/src/test/java/ae3/dao/ExperimentalDataTest.java
+++ b/atlas-web/src/test/java/ae3/dao/ExperimentalDataTest.java
@@ -27,6 +27,7 @@ import org.junit.After;
 import org.junit.Test;
 import uk.ac.ebi.gxa.data.AtlasDataDAO;
 import uk.ac.ebi.gxa.data.AtlasDataException;
+import uk.ac.ebi.gxa.utils.ResourceUtil;
 import uk.ac.ebi.gxa.web.filter.ResourceWatchdogFilter;
 import uk.ac.ebi.microarray.atlas.model.ArrayDesign;
 import uk.ac.ebi.microarray.atlas.model.Assay;
@@ -146,7 +147,7 @@ public class ExperimentalDataTest {
 
     private static File getTestNCDir() throws URISyntaxException {
         // won't work for JARs, networks and stuff, but so far so good...
-        return new File(ExperimentalData.class.getClassLoader().getResource("").getPath());
+        return ResourceUtil.getResourceRoot(ExperimentalDataTest.class);
     }
 
     @After


### PR DESCRIPTION
When you run tests from IntelliJ IDEA, our `getClass().getClassLoader().getResource("")` doesn't do the job: all the classes share the same classloader regardless of the source directory. Hence, lots of tests were failing which impeded local testing (and especially debug).

Adjusted the approach (thanks to Jevgeni Kabanov and his answer at http://stackoverflow.com/questions/227486/find-where-java-class-is-loaded-from)
