### PR TITLE
trac 3089: Double click on 'more>>' renders the same gene row twice

### DIFF
--- a/atlas-web/src/main/webapp/WEB-INF/jsp/genepage/gene-index.jsp
+++ b/atlas-web/src/main/webapp/WEB-INF/jsp/genepage/gene-index.jsp
@@ -51,15 +51,20 @@
         $(document).ready(function() {
 
             $("#moreResults").each(function() {
-                var link = $(this);
+                $(this).click(function(e) {
+                    var  link = $(this),
+                         url = link.attr("href"),
+                         html = $("<div><span class='loading'>&nbsp;</span></div>");
 
-                link.click(function() {
+                    link.hide();
+                    link.before(html);
+
                     $.ajax({
-                        url:link.attr("href"),
+                        url: url,
                         cache:false,
                         dataType:"json",
                         success: function(data) {
-                            var html = $("<div/>");
+                            html.empty();
                             var sample = $("#geneList a").get(0);
                             for (var i = 0; i < data.genes.length; i++) {
                                 var gene = data.genes[i];
@@ -77,16 +82,11 @@
                                 html.append(" ");
                             }
 
-                            /* chrome 9.0.597.102 has some problems of showing thousands of children in one div;
-                             * so we wrap new gene lists in <div/> */
-                            link.before(html);
-
                             if (data.nextQuery) {
-                                var href = link.attr("href");
-                                var j = href.indexOf("?");
-                                link.attr("href", href.substring(0, (j < 0 ? href.length : j)) + data.nextQuery);
-                            } else {
-                                link.remove();
+                                var j = url.indexOf("?"),
+                                    newUrl = url.substring(0, (j < 0 ? url.length : j)) + data.nextQuery;
+                                link.attr("href", newUrl);
+                                link.show();
                             }
                         }
                     });
@@ -105,7 +105,7 @@
 
         <jsp:include page="../includes/atlas-header.jsp"/>
 
-        <c:set var="url"><c:url value="/gene/index.htm"/></c:set>
+        <c:set var="url">${contextPath}/gene/index.htm</c:set>
         <div class="alphabet-index">
             <c:forTokens items="123 a b c d e f g h i j k l m n o p q r s t u v w x y z" delims=" " var="letter">
                <c:set var="prefix" value="${letter == '123' ? '0' : letter}"/>
@@ -117,7 +117,7 @@
         <div id="geneList" class="gene-list">
             <div>
                 <c:forEach var="gene" items="${genes}" varStatus="status">
-                    <a id="${gene.identifier}" href='<c:url value="/gene/${gene.identifier}"/>'
+                    <a id="${gene.identifier}" href="${contextPath}/gene/${gene.identifier}"
                        title="Gene Expression Atlas Data For ${gene.name}">
                         <nobr>${gene.name}</nobr>
                     </a>
@@ -125,7 +125,7 @@
             </div>
 
             <c:if test="${! empty nextQuery}">
-                <a id="moreResults" href='<c:url value="/gene/index.html${nextQuery}"/>'>
+                <a id="moreResults" href="${contextPath}/gene/index.html${nextQuery}">
                     <nobr>more&gt;&gt;</nobr>
                 </a>
             </c:if>

--- a/atlas-web/src/main/webapp/WEB-INF/jsp/genepage/gene-index.jsp
+++ b/atlas-web/src/main/webapp/WEB-INF/jsp/genepage/gene-index.jsp
@@ -52,19 +52,15 @@
 
             $("#moreResults").each(function() {
                 $(this).click(function(e) {
-                    var  link = $(this),
-                         url = link.attr("href"),
-                         html = $("<div><span class='loading'>&nbsp;</span></div>");
+                    var link = $(this),
+                            url = link.attr("href");
 
                     link.hide();
-                    link.before(html);
 
-                    $.ajax({
+                    atlas.ajaxLoader({
                         url: url,
-                        cache:false,
-                        dataType:"json",
-                        success: function(data) {
-                            html.empty();
+                        onSuccess: function(data) {
+                            var html = $("<div/>");
                             var sample = $("#geneList a").get(0);
                             for (var i = 0; i < data.genes.length; i++) {
                                 var gene = data.genes[i];
@@ -82,18 +78,19 @@
                                 html.append(" ");
                             }
 
+                            link.before(html);
+
                             if (data.nextQuery) {
                                 var j = url.indexOf("?"),
-                                    newUrl = url.substring(0, (j < 0 ? url.length : j)) + data.nextQuery;
+                                        newUrl = url.substring(0, (j < 0 ? url.length : j)) + data.nextQuery;
                                 link.attr("href", newUrl);
                                 link.show();
                             }
                         }
-                    });
+                    }).load({}, link.parent());
                     return false;
                 });
             });
-
         });
     </script>
 </head>

--- a/atlas-web/src/main/webapp/atlas.css
+++ b/atlas-web/src/main/webapp/atlas.css
@@ -314,6 +314,12 @@ padding: 0;
     height: 1%;
 }
 
+.loading {
+    background: transparent url(images/indicator.gif) no-repeat;
+    padding-left: 16px;
+    display: inline-block;
+}
+
 .waiter2 {
     border: none;
     position: absolute;

--- a/atlas-web/src/main/webapp/scripts/src/core/main.js
+++ b/atlas-web/src/main/webapp/scripts/src/core/main.js
@@ -71,7 +71,15 @@ var atlas = (function(A, $) {
      * @param uri - an URI to extend
      */
     A.fullPathFor = function(uri) {
-        return "/" + contextPath + "/" + normalizePath(uri);
+        uri = uri || "";
+        if (uri.length > 4 && uri.substring(0, 4) === "http") {
+            return uri;
+        }
+        var np = normalizePath(uri);
+        if (np.length >= contextPath.length && np.substring(0, contextPath.length) === contextPath) {
+            return "/" + np;
+        }
+        return "/" + contextPath + "/" + np;
     };
 
     /**

--- a/atlas-web/src/main/webapp/scripts/src/core/utils.js
+++ b/atlas-web/src/main/webapp/scripts/src/core/utils.js
@@ -192,7 +192,7 @@
 
         function failureHandler(request, errorType, errorMessage) {
             var context = opts.context || _this;
-            if (opts.onFailure()) {
+            if (opts.onFailure) {
                 opts.onFailure.apply(context, arguments);
             } else {
                 A.logError({


### PR DESCRIPTION
Trac ticket to reference to: http://bar.ebi.ac.uk:8080/trac/ticket/3089

The main idea of the fix is to hide the "more" link before calling ajax request.. 

Other changes:
- atlas.ajaxLoader now can show/hide activity indicator
- c:url tag removed as it useless and adds jsessionid to the url

@alf239, @rpetry - please review
