### PR TITLE
bugfix #3283: AtlasExperimentQueryParserTest broken

### DIFF
--- a/atlas-web/src/test/java/ae3/service/experiment/AtlasExperimentQueryParserTest.java
+++ b/atlas-web/src/test/java/ae3/service/experiment/AtlasExperimentQueryParserTest.java
@@ -127,7 +127,7 @@ public class AtlasExperimentQueryParserTest {
         assertTrue(query.getAnyFactorValues().isEmpty());
         assertTrue(query.getGeneIdentifiers().isEmpty());
         assertEquals(0, query.getStart());
-        assertEquals(DEFAULT_ROWS, query.getRows());
+        assertEquals(Integer.MAX_VALUE, query.getRows());
     }
 
     @Test


### PR DESCRIPTION
"listAll" returns all experiments with no paging

@alf239, @rpetry - please, review
