### PR TITLE
Trac 2856 Organism search, assays number

### DIFF
--- a/atlas-index-api/src/main/resources/solr/expt/conf/schema.xml
+++ b/atlas-index-api/src/main/resources/solr/expt/conf/schema.xml
@@ -287,8 +287,9 @@ but may be good for SKUs.  Can insert dashes in the wrong place and still match.
         <field name="alltext" type="text" indexed="true" stored="false" multiValued="true"/>
 
         <field name="platform" type="text" indexed="true" stored="true" multiValued="false"/>
-        <field name="organism" type="text" indexed="true" stored="true" multiValued="false"/>
+        <field name="organism" type="text" indexed="true" stored="true" multiValued="true"/>
         <field name="numSamples" type="sint" indexed="true" stored="true" multiValued="false"/>
+        <field name="numAssays" type="sint" indexed="true" stored="true" multiValued="false"/>
 
         <field name="assetCaption" type="text" indexed="true" stored="true" multiValued="true"/>
         <field name="assetDescription" type="text" indexed="true" stored="true" multiValued="true"/>

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/web/controller/ExperimentIndexLine.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/web/controller/ExperimentIndexLine.java
@@ -37,6 +37,10 @@ public class ExperimentIndexLine {
         return experiment.getSamples().size();
     }
 
+    public int getNumAssays() {
+        return experiment.getAssays().size();
+    }
+
     public Date getLoadDate() {
         return experiment.getLoadDate();
     }

--- a/atlas-web/src/main/webapp/WEB-INF/jsp/experimentpage/experiment-index.jsp
+++ b/atlas-web/src/main/webapp/WEB-INF/jsp/experimentpage/experiment-index.jsp
@@ -81,6 +81,10 @@
                            class="external">${experiment.pubmedId}</a>
                     </c:if>
                 </display:column>
+                <display:column property="numAssays" sortable="true" sortName="numAssays"
+                                title="Assays" class="number">
+                    <a href="${pageContext.request.contextPath}/experimentDesign/${experiment.accession}">${experiment.accession}</a>
+                </display:column>
                 <display:column property="numSamples" sortable="true" sortName="numSamples"
                                 title="Samples" class="number"/>
                 <%-- Postponed until implemented

--- a/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/ExperimentAtlasIndexBuilderService.java
+++ b/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/ExperimentAtlasIndexBuilderService.java
@@ -37,13 +37,12 @@ import uk.ac.ebi.microarray.atlas.model.*;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 import static com.google.common.base.Joiner.on;
 import static com.google.common.collect.Collections2.transform;
+import static com.google.common.collect.Sets.*;
 
 /**
  * An {@link IndexBuilderService} that generates index documents from the experiments in the Atlas database.
@@ -131,8 +130,8 @@ public class ExperimentAtlasIndexBuilderService extends IndexBuilderService {
             getLog().trace("No assays present for {}", experiment);
         }
 
-        Set<String> assayPropertyNames = new HashSet<String>();
-        Set<String> arrayDesignAccessions = new LinkedHashSet<String>();
+        Set<String> assayPropertyNames = newHashSet();
+        Set<String> arrayDesignAccessions = newLinkedHashSet();
         for (Assay assay : experiment.getAssays()) {
             if (assay.hasNoProperties()) {
                 getLog().trace("No properties present for {} ({})", assay);
@@ -145,11 +144,14 @@ public class ExperimentAtlasIndexBuilderService extends IndexBuilderService {
         }
         solrInputDoc.addField("a_properties", assayPropertyNames);
         solrInputDoc.addField("platform", on(",").join(arrayDesignAccessions));
+        solrInputDoc.addField("numAssays", experiment.getAssays().size());
     }
 
     private void addSampleInformation(SolrInputDocument solrInputDoc, Experiment experiment) {
-        Set<String> samplePropertyNames = new HashSet<String>();
+        Set<String> samplePropertyNames = newHashSet();
+        Set<String> organismNames = newTreeSet();
         for (Sample sample : experiment.getSamples()) {
+            organismNames.add(sample.getOrganism().getName());
             if (sample.hasNoProperties()) {
                 getLog().trace("No properties present for {}", sample);
             }
@@ -162,6 +164,7 @@ public class ExperimentAtlasIndexBuilderService extends IndexBuilderService {
         }
         solrInputDoc.addField("s_properties", samplePropertyNames);
         solrInputDoc.addField("numSamples", experiment.getSamples().size());
+        solrInputDoc.addField("organism", organismNames);
     }
 
     private void addAssetInformation(SolrInputDocument solrInputDoc, Experiment experiment) {


### PR DESCRIPTION
- Samples' organism is added to the index
- Assays number is stored

That enables us to sort experiment index page by assays number, and search by organism adding queries like `q=organism:homo` to the URL
