### PR TITLE
trac #3295: thumbnail links on gene page are broken

### DIFF
--- a/atlas-web/src/main/webapp/scripts/src/core/utils.js
+++ b/atlas-web/src/main/webapp/scripts/src/core/utils.js
@@ -262,9 +262,11 @@
      * context path to its "href" attribute value.
      */
     $.fn.atlasRelativeHref = function() {
-        var url = $(this).attr("atlas-uri");
-        if (url) {
-            $(this).attr("href", A.fullPathFor(url));
-        }
+        $(this).each(function() {
+            var url = $(this).attr("atlas-uri");
+            if (url) {
+                $(this).attr("href", A.fullPathFor(url));
+            }
+        });
     }
 })(atlas || {}, jQuery);


### PR DESCRIPTION
trac issue: http://bar.ebi.ac.uk:8080/trac/ticket/3295

Silly bug.. my bad.

@alf239, @rpetry - please, review 
