### PR TITLE
SHA1 digest added to listAll call

### DIFF
--- a/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/ExperimentDAO.java
+++ b/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/ExperimentDAO.java
@@ -62,7 +62,13 @@ public class ExperimentDAO extends AbstractDAO<Experiment> {
         return NAME_COL;
     }
 
-
+    /**
+     * Same as {@link #getAll} but ensures ontology mapping preloading
+     * <p/>
+     * DO NOT use it anywhere but index builder: it's useless for anything but full index.
+     *
+     * @return list of all experiments
+     */
     public List<Experiment> getExperimentsPreparedForIndexing() {
         preloadDetails();
         return getAll();

--- a/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/ExperimentDAO.java
+++ b/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/ExperimentDAO.java
@@ -61,4 +61,22 @@ public class ExperimentDAO extends AbstractDAO<Experiment> {
     public String getNameColumn() {
         return NAME_COL;
     }
+
+
+    public List<Experiment> getExperimentsPreparedForIndexing() {
+        preloadDetails();
+        return getAll();
+    }
+
+    /**
+     * An awful hack preloading experiment details in order to make indexing fast. Only needed for indexing.
+     * <p/>
+     * DO NOT use it anywhere else: it's useless for anything but full index.
+     */
+    private void preloadDetails() {
+        final List<?> sp = template.find("select sp from SampleProperty sp left join fetch sp.terms");
+        log.debug("{} sample properties", sp.size());
+        final List<?> ap = template.find("select ap from AssayProperty ap left join fetch ap.terms");
+        log.debug("{} assay properties", ap.size());
+    }
 }

--- a/atlas-index-api/src/main/resources/solr/expt/conf/schema.xml
+++ b/atlas-index-api/src/main/resources/solr/expt/conf/schema.xml
@@ -255,6 +255,8 @@ but may be good for SKUs.  Can insert dashes in the wrong place and still match.
         <field name="description" type="text" indexed="true" stored="true"/>
         <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
 
+        <field name="digest" type="string" indexed="false" stored="true"/>
+
         <field name="top_gene_ids" type="text" indexed="true" stored="true" multiValued="true"/>
         <field name="top_proxy_ids" type="text" indexed="true" stored="true" multiValued="true"/>
         <field name="top_de_indexes" type="text" indexed="true" stored="true" multiValued="true"/>

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
@@ -356,14 +356,15 @@ public class Experiment {
         return result;
     }
 
-    public String getSha1() {
+    public String getDigest() {
         final MessageDigest digest = getDigestInstance();
         update(digest, accession);
         update(digest, description);
         update(digest, articleAbstract);
         update(digest, performer);
         update(digest, lab);
-        update(digest, DATE_FORMAT.get().format(loadDate.getTime()));
+        if (loadDate != null)
+            update(digest, DATE_FORMAT.get().format(loadDate.getTime()));
         update(digest, pmid);
         for (Asset asset : assets) {
             update(digest, asset.getDescription());
@@ -379,9 +380,9 @@ public class Experiment {
             for (AssayProperty property : assay.getProperties()) {
                 update(digest, property.getName());
                 update(digest, property.getValue());
-                for (OntologyTerm term : property.getTerms()) {
-                    update(digest, term.getAccession());
-                }
+//                for (OntologyTerm term : property.getTerms()) {
+//                    update(digest, term.getAccession());
+//                }
             }
         }
         for (Sample sample : samples) {
@@ -391,9 +392,9 @@ public class Experiment {
             for (SampleProperty property : sample.getProperties()) {
                 update(digest, property.getName());
                 update(digest, property.getValue());
-                for (OntologyTerm term : property.getTerms()) {
-                    update(digest, term.getAccession());
-                }
+//                for (OntologyTerm term : property.getTerms()) {
+//                    update(digest, term.getAccession());
+//                }
             }
         }
         update(digest, Boolean.toString(isprivate));

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
@@ -380,9 +380,9 @@ public class Experiment {
             for (AssayProperty property : assay.getProperties()) {
                 update(digest, property.getName());
                 update(digest, property.getValue());
-//                for (OntologyTerm term : property.getTerms()) {
-//                    update(digest, term.getAccession());
-//                }
+                for (OntologyTerm term : property.getTerms()) {
+                    update(digest, term.getAccession());
+                }
             }
         }
         for (Sample sample : samples) {
@@ -392,9 +392,9 @@ public class Experiment {
             for (SampleProperty property : sample.getProperties()) {
                 update(digest, property.getName());
                 update(digest, property.getValue());
-//                for (OntologyTerm term : property.getTerms()) {
-//                    update(digest, term.getAccession());
-//                }
+                for (OntologyTerm term : property.getTerms()) {
+                    update(digest, term.getAccession());
+                }
             }
         }
         update(digest, Boolean.toString(isprivate));

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
@@ -45,6 +45,12 @@ import static uk.ac.ebi.gxa.utils.DigestUtil.*;
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
 public class Experiment {
+    public static final ThreadLocal<SimpleDateFormat> DATE_FORMAT = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat("dd-MM-yyyy");
+        }
+    };
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "experimentSeq")
     @SequenceGenerator(name = "experimentSeq", sequenceName = "A2_EXPERIMENT_SEQ", allocationSize = 1)
@@ -357,7 +363,7 @@ public class Experiment {
         update(digest, articleAbstract);
         update(digest, performer);
         update(digest, lab);
-        update(digest, new SimpleDateFormat("yyyyMMdd").format(loadDate.getTime()));
+        update(digest, DATE_FORMAT.get().format(loadDate.getTime()));
         update(digest, pmid);
         for (Asset asset : assets) {
             update(digest, asset.getDescription());

--- a/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
+++ b/atlas-model/src/main/java/uk/ac/ebi/microarray/atlas/model/Experiment.java
@@ -388,7 +388,6 @@ public class Experiment {
             update(digest, sample.getAccession());
             update(digest, sample.getChannel());
             update(digest, sample.getOrganism().getName());
-            update(digest, sample.getOrganism().getName());
             for (SampleProperty property : sample.getProperties()) {
                 update(digest, property.getName());
                 update(digest, property.getValue());

--- a/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/DigestUtil.java
+++ b/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/DigestUtil.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2008-2011 Microarray Informatics Team, EMBL-European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * For further details of the Gene Expression Atlas project, including source code,
+ * downloads and documentation, please see:
+ *
+ * http://gxa.github.com/gxa
+ */
+
+package uk.ac.ebi.gxa.utils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
+import java.util.List;
+
+import static com.google.common.io.Closeables.closeQuietly;
+import static java.util.Arrays.asList;
+import static java.util.Collections.sort;
+import static uk.ac.ebi.gxa.exceptions.LogUtil.createUnexpected;
+
+/**
+ */
+public class DigestUtil {
+    private static final byte[] SEPARATOR = {(byte) 0xA3, (byte) 141};
+    private static final String SHA_1 = "SHA-1";
+
+    public static byte[] digest(File... files) throws IOException {
+        return digest(asList(files));
+    }
+
+    public static byte[] digest(List<File> files) throws IOException {
+        try {
+            MessageDigest digest = getDigestInstance();
+            sort(files, new Comparator<File>() {
+                @Override
+                public int compare(File o1, File o2) {
+                    try {
+                        return o1.getCanonicalPath().compareTo(o2.getCanonicalPath());
+                    } catch (IOException e) {
+                        throw createUnexpected("Cannot get canonical path", e);
+                    }
+                }
+            });
+            for (File f : files) {
+                update(digest, f);
+                putSeparator(digest);
+            }
+            return digest.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw createUnexpected("Cannot get a digester", e);
+        }
+    }
+
+    public static MessageDigest getDigestInstance() throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance(SHA_1);
+    }
+
+    public static void update(MessageDigest complete, File f) throws IOException {
+        InputStream fis = null;
+        try {
+            fis = new FileInputStream(f);
+
+            byte[] buffer = new byte[1024];
+            int numRead;
+            do {
+                numRead = fis.read(buffer);
+                if (numRead > 0) {
+                    complete.update(buffer, 0, numRead);
+                }
+            } while (numRead != -1);
+        } finally {
+            closeQuietly(fis);
+        }
+    }
+
+    public static void update(MessageDigest digest, String s) {
+        digest.update(s.getBytes(Charset.forName("UTF-8")));
+        putSeparator(digest);
+    }
+
+    private static void putSeparator(MessageDigest digest) {
+        digest.update(SEPARATOR);
+    }
+}

--- a/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/DigestUtil.java
+++ b/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/DigestUtil.java
@@ -22,11 +22,12 @@
 
 package uk.ac.ebi.gxa.utils;
 
+import org.apache.commons.codec.binary.Hex;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -42,7 +43,8 @@ import static uk.ac.ebi.gxa.exceptions.LogUtil.createUnexpected;
  */
 public class DigestUtil {
     private static final byte[] SEPARATOR = {(byte) 0xA3, (byte) 141};
-    private static final String SHA_1 = "SHA-1";
+    private static final String ALGORITHM = "MD5";
+    private static final Charset CHARSET = Charset.forName("UTF-8");
 
     public static byte[] digest(File... files) throws IOException {
         return digest(asList(files));
@@ -69,7 +71,7 @@ public class DigestUtil {
 
     public static MessageDigest getDigestInstance() {
         try {
-            return MessageDigest.getInstance(SHA_1);
+            return MessageDigest.getInstance(ALGORITHM);
         } catch (NoSuchAlgorithmException e) {
             throw createUnexpected("Cannot get a digester", e);
         }
@@ -95,7 +97,7 @@ public class DigestUtil {
 
     public static void update(MessageDigest digest, String s) {
         if (s != null)
-            digest.update(s.getBytes(Charset.forName("UTF-8")));
+            digest.update(s.getBytes(CHARSET));
         putSeparator(digest);
     }
 
@@ -105,15 +107,11 @@ public class DigestUtil {
 
     /**
      * Converts byte array into a hex string
-     * <p/>
-     * Courtesy <a href="http://stackoverflow.com/users/77222/ayman">Ayman</a>, from
-     * <a href="http://stackoverflow.com/questions/332079/in-java-how-do-i-convert-a-byte-array-to-a-string-of-hex-digits-while-keeping-l/943963#943963">the StackOverflow answer</a>.
      *
      * @param bytes bytes to format
      * @return formatted hex string (lowercase)
      */
     public static String toHex(byte[] bytes) {
-        BigInteger bi = new BigInteger(1, bytes);
-        return String.format("%0" + (bytes.length << 1) + "x", bi);
+        return new String(Hex.encodeHex(bytes));
     }
 }

--- a/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/DigestUtil.java
+++ b/atlas-utils/src/main/java/uk/ac/ebi/gxa/utils/DigestUtil.java
@@ -43,7 +43,7 @@ import static uk.ac.ebi.gxa.exceptions.LogUtil.createUnexpected;
  */
 public class DigestUtil {
     private static final byte[] SEPARATOR = {(byte) 0xA3, (byte) 141};
-    private static final String ALGORITHM = "MD5";
+    private static final String ALGORITHM = "SHA1";
     private static final Charset CHARSET = Charset.forName("UTF-8");
 
     public static byte[] digest(File... files) throws IOException {

--- a/atlas-web/src/main/java/ae3/model/AtlasExperiment.java
+++ b/atlas-web/src/main/java/ae3/model/AtlasExperiment.java
@@ -161,7 +161,7 @@ public class AtlasExperiment {
     }
 
     private static String dateToString(Date date) {
-        return date == null ? null : (new SimpleDateFormat("dd-MM-yyyy").format(date));
+        return date == null ? null : new SimpleDateFormat("dd-MM-yyyy").format(date);
     }
 
     @RestOut(name = "loaddate")
@@ -171,6 +171,11 @@ public class AtlasExperiment {
 
     public Experiment getExperiment() {
         return experiment;
+    }
+
+    @RestOut
+    public String getSha1() {
+        return experiment.getSha1();
     }
 }
 

--- a/atlas-web/src/main/java/ae3/model/AtlasExperiment.java
+++ b/atlas-web/src/main/java/ae3/model/AtlasExperiment.java
@@ -168,8 +168,8 @@ public class AtlasExperiment {
     }
 
     @RestOut
-    public String getSha1() {
-        return experiment.getSha1();
+    public String getDigest() {
+        return (String) exptSolrDocument.getFieldValue("digest");
     }
 }
 

--- a/atlas-web/src/main/java/ae3/model/AtlasExperiment.java
+++ b/atlas-web/src/main/java/ae3/model/AtlasExperiment.java
@@ -32,7 +32,6 @@ import uk.ac.ebi.microarray.atlas.model.Experiment;
 import uk.ac.ebi.microarray.atlas.model.Property;
 
 import javax.annotation.Nonnull;
-import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static com.google.common.collect.Collections2.transform;
@@ -155,13 +154,8 @@ public class AtlasExperiment {
         return (Integer) exptSolrDocument.getFieldValue("numSamples");
     }
 
-    @RestOut(name = "archiveUrl")
-    public String getArchiveUrl() {
-        return "/data/" + this.getAccession() + ".zip";
-    }
-
     private static String dateToString(Date date) {
-        return date == null ? null : new SimpleDateFormat("dd-MM-yyyy").format(date);
+        return date == null ? null : Experiment.DATE_FORMAT.get().format(date);
     }
 
     @RestOut(name = "loaddate")

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/web/controller/WebPingController.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/web/controller/WebPingController.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2008-2011 Microarray Informatics Team, EMBL-European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * For further details of the Gene Expression Atlas project, including source code,
+ * downloads and documentation, please see:
+ *
+ * http://gxa.github.com/gxa
+ */
+
+package uk.ac.ebi.gxa.web.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import uk.ac.ebi.gxa.properties.AtlasProperties;
+
+/**
+ * @author alf
+ */
+@Controller
+public class WebPingController {
+    @Autowired
+    private AtlasProperties properties;
+
+    @ResponseBody
+    @RequestMapping(value = "/webping", method = RequestMethod.GET)
+    public String webping() {
+        return "Server: OK, " + properties.getSoftwareVersion();
+    }
+}

--- a/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/ExperimentAtlasIndexBuilderService.java
+++ b/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/ExperimentAtlasIndexBuilderService.java
@@ -65,7 +65,7 @@ public class ExperimentAtlasIndexBuilderService extends IndexBuilderService {
         super.processCommand(indexAll, progressUpdater);
 
         try {
-            final List<Experiment> experiments = experimentDAO.getAll();
+            final List<Experiment> experiments = experimentDAO.getExperimentsPreparedForIndexing();
 
             final int total = experiments.size();
             int num = 0;

--- a/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/ExperimentAtlasIndexBuilderService.java
+++ b/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/ExperimentAtlasIndexBuilderService.java
@@ -121,6 +121,8 @@ public class ExperimentAtlasIndexBuilderService extends IndexBuilderService {
         addSampleInformation(solrInputDoc, experiment);
         addAssetInformation(solrInputDoc, experiment);
 
+        solrInputDoc.addField("digest", experiment.getDigest());
+
         getLog().info("Finalising changes for {}", experiment);
         getSolrServer().add(solrInputDoc);
     }


### PR DESCRIPTION
`/api/v1?experiment=listAll&experimentInfoOnly` now has a `digest` field containing a digest of experiment's metadata. That enables us to find changed experiments in a situation when both servers run the same code version (that is, digest's source data is the same to the last bit).

The code around was clarified a bit in attempt to understand it. 

Bonus track: `webping` page, currently a basic `Server: OK, 2.0.10-58-g09519a0-sha1` one
