### PR TITLE
ticket 3201

### DIFF
--- a/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/GeneAtlasIndexBuilderService.java
+++ b/indexbuilder/src/main/java/uk/ac/ebi/gxa/index/builder/service/GeneAtlasIndexBuilderService.java
@@ -202,6 +202,7 @@ public class GeneAtlasIndexBuilderService extends IndexBuilderService {
         solrInputDoc.addField("identifier", bioEntity.getIdentifier());
 
         Set<String> propNames = new HashSet<String>();
+        boolean nameSet = false;
         for (BEPropertyValue prop : bioEntity.getProperties()) {
 
             String pv = prop.getValue();
@@ -212,6 +213,7 @@ public class GeneAtlasIndexBuilderService extends IndexBuilderService {
                 solrInputDoc.addField("orthologs", pv);
             } else if (p.toLowerCase().equals("symbol")) {
                 solrInputDoc.addField("name", pv);
+                nameSet = true;
             } else {
                 getLog().trace("Updating index, gene property " + p + " = " + pv);
                 solrInputDoc.addField("property_" + p, pv);
@@ -221,6 +223,10 @@ public class GeneAtlasIndexBuilderService extends IndexBuilderService {
         if (!propNames.isEmpty())
             solrInputDoc.setField("properties", propNames);
 
+        //To avoid empty "name" field, use identifier if beproperty, corresponding to "name" is missing
+        if (!nameSet) {
+            solrInputDoc.addField("name", bioEntity.getIdentifier());
+        }
         getLog().debug("Properties for " + bioEntity.getIdentifier() + " updated");
 
         return solrInputDoc;


### PR DESCRIPTION
 Fix: avoid empty "name" field: use identifier if beproperty corresponding to "name" is missing
