### PR TITLE
moving http proxy settings out of annotator module

### DIFF
--- a/annotator/pom.xml
+++ b/annotator/pom.xml
@@ -105,11 +105,5 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.5.6</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.1.2</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/annotator/src/main/java/uk/ac/ebi/gxa/annotator/loader/AnnotatorFactory.java
+++ b/annotator/src/main/java/uk/ac/ebi/gxa/annotator/loader/AnnotatorFactory.java
@@ -22,13 +22,8 @@
 
 package uk.ac.ebi.gxa.annotator.loader;
 
-import com.google.common.base.Strings;
-import org.apache.http.HttpHost;
-import org.apache.http.conn.params.ConnRoutePNames;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.apache.http.client.HttpClient;
+import org.springframework.beans.factory.annotation.Autowired;
 import uk.ac.ebi.gxa.annotator.dao.AnnotationSourceDAO;
 import uk.ac.ebi.gxa.annotator.model.BioMartAnnotationSource;
 import uk.ac.ebi.gxa.annotator.model.FileBasedAnnotationSource;
@@ -40,8 +35,6 @@ import uk.ac.ebi.gxa.dao.bioentity.BioEntityPropertyDAO;
  */
 
 public class AnnotatorFactory {
-    private static final String PROXY_HOST = "http.proxyHost";
-    private static final String PROXY_PORT = "http.proxyPort";
 
     @Autowired
     private AtlasBioEntityDataWriter beDataWriter;
@@ -53,26 +46,10 @@ public class AnnotatorFactory {
     private HttpClient httpClient;
 
     public BioMartAnnotator createBioMartAnnotator(BioMartAnnotationSource annSrc) {
-        setProxyIfExists(httpClient);
         return new BioMartAnnotator(annSrc, annSrcDAO, propertyDAO, beDataWriter, httpClient);
     }
 
     public <T extends FileBasedAnnotationSource> FileBasedAnnotator createFileBasedAnnotator(T annSrc) {
-        setProxyIfExists(httpClient);
         return new FileBasedAnnotator(annSrc, beDataWriter, httpClient);
-    }
-
-    public static void setProxyIfExists(HttpClient httpClient) {
-        String proxyHost = System.getProperty(PROXY_HOST);
-        String proxyPort = System.getProperty(PROXY_PORT);
-        if (!Strings.isNullOrEmpty(proxyHost) && !Strings.isNullOrEmpty(proxyPort)) {
-            try {
-                int port = Integer.parseInt(proxyPort);
-                final HttpHost proxy = new HttpHost(proxyHost, port, "http");
-                httpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
-            } catch (NumberFormatException nfe) {
-                // queisce
-            }
-        }
     }
 }

--- a/annotator/src/main/java/uk/ac/ebi/gxa/annotator/loader/biomart/MartVersionFinder.java
+++ b/annotator/src/main/java/uk/ac/ebi/gxa/annotator/loader/biomart/MartVersionFinder.java
@@ -45,7 +45,6 @@ public class MartVersionFinder implements VersionFinder<BioMartAnnotationSource>
     public String fetchOnLineVersion(BioMartAnnotationSource annSrc) {
 
         try {
-            AnnotatorFactory.setProxyIfExists(httpClient);
             MartServiceClientImpl martClient = MartServiceClientImpl.create(httpClient, annSrc);
             final String database = martClient.getMartLocation().getDatabase();
             return database.substring(database.lastIndexOf("_") + 1);

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/web/HttpClientFactoryBean.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/web/HttpClientFactoryBean.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2008-2012 Microarray Informatics Team, EMBL-European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * For further details of the Gene Expression Atlas project, including source code,
+ * downloads and documentation, please see:
+ *
+ * http://gxa.github.com/gxa
+ */
+
+package uk.ac.ebi.gxa.web;
+
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
+import org.apache.http.client.HttpClient;
+
+import java.net.ProxySelector;
+
+/**
+ * @author Olga Melnichuk
+ */
+public class HttpClientFactoryBean {
+
+    private ClientConnectionManager connManager;
+
+    public void setConnManager(ClientConnectionManager connManager) {
+        this.connManager = connManager;
+    }
+
+    public HttpClient createInstance() {
+        return applyProxySettings(new DefaultHttpClient(connManager));
+    }
+
+    private static DefaultHttpClient applyProxySettings(DefaultHttpClient httpClient) {
+        ProxySelectorRoutePlanner routePlanner = new ProxySelectorRoutePlanner(
+                httpClient.getConnectionManager().getSchemeRegistry(),
+                ProxySelector.getDefault());
+        httpClient.setRoutePlanner(routePlanner);
+        return httpClient;
+    }
+}

--- a/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
+++ b/atlas-web/src/main/webapp/WEB-INF/atlasApplicationContext.xml
@@ -207,13 +207,18 @@ http://www.springframework.org/schema/util/spring-util.xsd">
     </bean>
 
     <!-- http client -->
-
-    <bean id="httpClient" class="org.apache.http.impl.client.DefaultHttpClient">
-        <constructor-arg ref="httpClientConnectionManager"/>
+    <bean id="httpClientConnectionManager" class="org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager"
+          destroy-method="shutdown">
     </bean>
 
-    <bean id="httpClientConnectionManager" class="org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager"
-            destroy-method="shutdown">
+    <bean id="httpClientFactoryBean" class="uk.ac.ebi.gxa.web.HttpClientFactoryBean">
+        <property name="connManager" ref="httpClientConnectionManager"/>
+    </bean>
+
+    <bean id="httpClient"
+          class="org.apache.http.client.HttpClient"
+            factory-bean="httpClientFactoryBean"
+            factory-method="createInstance">
     </bean>
 
     <!-- Web interface component -->

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,13 @@
             <version>1.3.9</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.1.2</version>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- logging uses SLF4J throughout -->
         <dependency> <!-- this will allow redirection of java.util.logging calls via slf4j -->
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
httpclient proxy settings moved out of annotator module; now the settings applied just after the httpclient object is created in the atlas-web module; so every service could use it.
