### PR TITLE
cleaning httpClient maven dependencies.. 

### DIFF
--- a/annotator/pom.xml
+++ b/annotator/pom.xml
@@ -100,10 +100,17 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.5.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/annotator/pom.xml
+++ b/annotator/pom.xml
@@ -105,6 +105,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.5.6</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/atlas-web/pom.xml
+++ b/atlas-web/pom.xml
@@ -388,6 +388,13 @@
             <artifactId>cglib</artifactId>
             <version>2.2</version>
         </dependency>
+
+        <!-- etc. -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,12 @@
                 <version>1.8.0.10</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.1.2</version>
+                <scope>compile</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -331,13 +337,6 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>1.3.9</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.1.2</version>
-            <scope>compile</scope>
         </dependency>
 
         <!-- logging uses SLF4J throughout -->


### PR DESCRIPTION
- httpClient dependency declared through dependencyManagement section now
- added scope 'test' for slf4j-simple in annotator; as it could be used for tests only.. (it would be nice to have the same output logger log4j everywhere in the code in the future)
