### PR TITLE
data matrix file loader improved a bit

### DIFF
--- a/atlas-loader/src/main/java/uk/ac/ebi/gxa/loader/datamatrix/DataMatrixFileFormatException.java
+++ b/atlas-loader/src/main/java/uk/ac/ebi/gxa/loader/datamatrix/DataMatrixFileFormatException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2008-2012 Microarray Informatics Team, EMBL-European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * For further details of the Gene Expression Atlas project, including source code,
+ * downloads and documentation, please see:
+ *
+ * http://gxa.github.com/gxa
+ */
+
+package uk.ac.ebi.gxa.loader.datamatrix;
+
+/**
+ * @author Olga Melnichuk
+ */
+public class DataMatrixFileFormatException extends Exception {
+
+    public DataMatrixFileFormatException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
When I tried to load E-MTAB-25 from AE2 through processed data file I found that in the corresponding netCDF file the most part of DEacc array contains "" strings. Unfortunately there were no any warnings or errors in the log and I spent a day to find out what was wrong.

The problem was solved by fixing the processed data file. However I improved the loader code a bit: now it throws an error if design element accession is an empty string.
