### PR TITLE
trac 3291: Re-selecting 'All factor values' fails to refresh best genes table on experiment page

### DIFF
--- a/atlas-web/src/main/webapp/WEB-INF/jsp/experimentpage/experiment.jsp
+++ b/atlas-web/src/main/webapp/WEB-INF/jsp/experimentpage/experiment.jsp
@@ -327,7 +327,7 @@
                         </td>
                         <td class="padded" colspan="2">
                             <select id="efvFilter" style="width:100%;">
-                                <option value="">All factor values</option>
+                                <option value="||">All factor values</option>
                                 <c:forEach var="EF" items="${exp.experimentFactors}">
                                     <optgroup label="${f:escapeXml(EF.displayName)}">
                                         <c:forEach var="EFV" items="${exp.factorValuesForEF[EF]}">


### PR DESCRIPTION
I put value "||" for any ef/efv option in the select box; this will clean up corresponding parameters in the search request..
