### PR TITLE
Trac 3430: 'List' search queries are very slow

### DIFF
--- a/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/DataProxy.java
+++ b/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/DataProxy.java
@@ -111,4 +111,8 @@ interface DataProxy extends Closeable {
     FloatMatrixProxy getTStatistics(int[] des) throws AtlasDataException, StatisticsNotFoundException;
 
     FloatMatrixProxy getPValues(int[] des) throws AtlasDataException, StatisticsNotFoundException;
+
+    FloatMatrixProxy getAllTStatistics() throws AtlasDataException, StatisticsNotFoundException;
+
+    FloatMatrixProxy getAllPValues() throws AtlasDataException, StatisticsNotFoundException;
 }

--- a/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/ExperimentWithData.java
+++ b/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/ExperimentWithData.java
@@ -62,10 +62,10 @@ public class ExperimentWithData implements Closeable {
         this.experiment = experiment;
     }
 
-    public StatisticsCursor getStatistics(ArrayDesign arrayDesign, int designElementId,
+    public StatisticsCursor getStatistics(ArrayDesign arrayDesign, int deIndex,
                                           Predicate<Pair<String, String>> efvPredicate)
             throws AtlasDataException, StatisticsNotFoundException {
-        return new StatisticsCursor(getProxy(arrayDesign), efvPredicate, designElementId);
+        return new StatisticsCursor(getProxy(arrayDesign), efvPredicate, deIndex);
     }
 
     public StatisticsCursor getStatistics(ArrayDesign ad, int[] deIndices)

--- a/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/NetCDFProxy.java
+++ b/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/NetCDFProxy.java
@@ -31,6 +31,7 @@ import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * interface class for read access to NetCDF files
@@ -79,6 +80,9 @@ abstract class NetCDFProxy implements DataProxy {
     FloatMatrixProxy readFloatValuesForRowIndices(NetcdfFile netCDF, int[] rowIndices,
                                                   String varName) throws AtlasDataException {
         try {
+            if (rowIndices == null) {
+                throw new IllegalArgumentException("'rowIndices' should not be null");
+            }
             Variable variable = netCDF.findVariable(varName);
             int[] shape = variable.getShape();
 

--- a/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/NetCDFProxyV1.java
+++ b/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/NetCDFProxyV1.java
@@ -249,15 +249,21 @@ final class NetCDFProxyV1 extends NetCDFProxy {
     }
 
     public FloatMatrixProxy getTStatistics(int[] des) throws AtlasDataException {
-        return des == null ?
-                readFloatValuesForAllRows(netCDF, "TSTAT") :
-                readFloatValuesForRowIndices(netCDF, des, "TSTAT");
+        return readFloatValuesForRowIndices(netCDF, des, "TSTAT");
     }
 
     public FloatMatrixProxy getPValues(int[] des) throws AtlasDataException {
-        return des == null ?
-                readFloatValuesForAllRows(netCDF, "PVAL") :
-                readFloatValuesForRowIndices(netCDF, des, "PVAL");
+        return readFloatValuesForRowIndices(netCDF, des, "PVAL");
+    }
+
+    @Override
+    public FloatMatrixProxy getAllTStatistics() throws AtlasDataException {
+        return readFloatValuesForAllRows(netCDF, "TSTAT");
+    }
+
+    @Override
+    public FloatMatrixProxy getAllPValues() throws AtlasDataException {
+        return readFloatValuesForAllRows(netCDF, "PVAL");
     }
 
     /**

--- a/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/NetCDFProxyV2.java
+++ b/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/NetCDFProxyV2.java
@@ -253,13 +253,13 @@ final class NetCDFProxyV2 extends NetCDFProxy {
     }
 
     @Override
-    public FloatMatrixProxy getTStatistics(int[] des) throws AtlasDataException, StatisticsNotFoundException {
-        return readFloatValuesForAllRows(stats(), "TSTAT");
+    public FloatMatrixProxy getTStatistics(int[] deIndices) throws AtlasDataException, StatisticsNotFoundException {
+        return readFloatValuesForRowIndices(stats(), deIndices, "TSTAT");
     }
 
     @Override
-    public FloatMatrixProxy getPValues(int[] des) throws AtlasDataException, StatisticsNotFoundException {
-        return readFloatValuesForAllRows(stats(), "PVAL");
+    public FloatMatrixProxy getPValues(int[] deIndices) throws AtlasDataException, StatisticsNotFoundException {
+        return readFloatValuesForRowIndices(stats(), deIndices, "PVAL");
     }
 
     private NetcdfFile stats() throws StatisticsNotFoundException {

--- a/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/NetCDFProxyV2.java
+++ b/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/NetCDFProxyV2.java
@@ -262,6 +262,16 @@ final class NetCDFProxyV2 extends NetCDFProxy {
         return readFloatValuesForRowIndices(stats(), deIndices, "PVAL");
     }
 
+    @Override
+    public FloatMatrixProxy getAllTStatistics() throws AtlasDataException, StatisticsNotFoundException {
+        return readFloatValuesForAllRows(stats(), "TSTAT");
+    }
+
+    @Override
+    public FloatMatrixProxy getAllPValues() throws AtlasDataException, StatisticsNotFoundException {
+        return readFloatValuesForAllRows(stats(), "PVAL");
+    }
+
     private NetcdfFile stats() throws StatisticsNotFoundException {
         if (statisticsNetCDF == null) {
             throw new StatisticsNotFoundException();

--- a/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/StatisticsCursor.java
+++ b/atlas-data-storage/src/main/java/uk/ac/ebi/gxa/data/StatisticsCursor.java
@@ -97,8 +97,8 @@ public class StatisticsCursor implements DesignElementStatistics {
         this.des = des;
 
         uEFVs = dataProxy.getUniqueEFVs();
-        tstat = dataProxy.getTStatistics(des);
-        pvals = dataProxy.getPValues(des);
+        tstat = des == null ? dataProxy.getAllTStatistics() : dataProxy.getTStatistics(des);
+        pvals = des == null ? dataProxy.getAllPValues() : dataProxy.getPValues(des);
         factors = dataProxy.getFactors();
         factorValues = dataProxy.getFactorValues();
         deAccessions = dataProxy.getDesignElementAccessions();

--- a/atlas-web/src/main/java/ae3/model/ListResultRow.java
+++ b/atlas-web/src/main/java/ae3/model/ListResultRow.java
@@ -43,11 +43,10 @@ public class ListResultRow implements Comparable<ListResultRow> {
     private final float minPval_up;
     private final float minPval_dn;
     private AtlasGene gene;
-    public final String designElementAccession;
 
-    Collection<ListResultRowExperiment> exp_list = new ArrayList<ListResultRowExperiment>();
+    private final Collection<ListResultRowExperiment> exp_list = new ArrayList<ListResultRowExperiment>();
 
-    public ListResultRow(String ef, String efv, int count_up, int count_dn, int count_no, float min_up, float min_dn, String designElementAccession) {
+    public ListResultRow(String ef, String efv, int count_up, int count_dn, int count_no, float min_up, float min_dn) {
         this.ef = ef;
         this.fv = efv;
         this.count_dn = count_dn;
@@ -55,17 +54,11 @@ public class ListResultRow implements Comparable<ListResultRow> {
         this.count_no = count_no;
         this.minPval_dn = min_dn;
         this.minPval_up = min_up;
-        this.designElementAccession = designElementAccession;
     }
 
     @RestOut(name = "efv")
     public String getFv() {
         return fv;
-    }
-
-    public String getShortFv() {
-        String fv_short = StringUtils.capitalize(fv);
-        return fv_short.length() > 30 ? fv_short.substring(0, 30) + "..." : fv_short;
     }
 
     @RestOut(name = "ef")
@@ -94,30 +87,9 @@ public class ListResultRow implements Comparable<ListResultRow> {
         return (count_dn > 0) ? minPval_dn : minPval_up;
     }
 
-    public String getRow_id() {
-        return StringEscapeUtils.escapeHtml(ef) + StringEscapeUtils.escapeHtml(fv);
-    }
-
-    public String getText() {
-        if (isMixedCell())
-            return " found over-expressed in " + fv + " in " + count_up + " experiments and under-expressed in " + count_dn + " experiments";
-        else if (count_up > 0)
-            return " found over-expressed in " + fv + " in " + count_up + " experiments";
-        else if (count_dn > 0)
-            return " found under-expressed in " + fv + " in " + count_dn + " experiments";
-        else
-            return "";
-    }
-
     public boolean isMixedCell() {
         return (count_dn > 0 && count_up > 0);
     }
-
-    public String getExpr() {
-        return (count_dn > 0) ? "dn" :
-                (count_up > 0) ? "up" : "";
-    }
-
 
     public int getNoStudies() {
         return count_dn + count_up;
@@ -139,10 +111,6 @@ public class ListResultRow implements Comparable<ListResultRow> {
         return gene.getGeneSpecies();
     }
 
-    public String getGene_identifier() {
-        return gene.getGeneIdentifier();
-    }
-
     public long getGene_id() {
         return gene.getGeneId();
     }
@@ -153,7 +121,7 @@ public class ListResultRow implements Comparable<ListResultRow> {
     }
 
     public void setExp_list(Collection<ListResultRowExperiment> exp_list) {
-        this.exp_list = exp_list;
+        this.exp_list.addAll(exp_list);
     }
 
     public int compareTo(ListResultRow o) {
@@ -192,10 +160,6 @@ public class ListResultRow implements Comparable<ListResultRow> {
         result = 31 * result + (minPval_up != +0.0f ? Float.floatToIntBits(minPval_up) : 0);
         result = 31 * result + (minPval_dn != +0.0f ? Float.floatToIntBits(minPval_dn) : 0);
         return result;
-    }
-
-    public String getDesignElementAccession() {
-        return designElementAccession != null ? designElementAccession : "";
     }
 }
 

--- a/atlas-web/src/main/java/ae3/model/ListResultRowExperiment.java
+++ b/atlas-web/src/main/java/ae3/model/ListResultRowExperiment.java
@@ -51,16 +51,10 @@ public class ListResultRowExperiment {
         this.deAccession = deAccession;
     }
 
-    @RestOut(name = "pvalue")
     public float getPvalue() {
         return pvalue;
     }
 
-    public long getExperimentId() {
-        return experiment.getId();
-    }
-
-    @RestOut(name = "accession")
     public String getExperimentAccession() {
         return experiment.getAccession();
     }
@@ -69,12 +63,10 @@ public class ListResultRowExperiment {
         return experiment.getDescription();
     }
 
-    @RestOut(name = "expression")
     public UpDownExpression getUpdn() {
         return updn;
     }
 
-    @RestOut(name = "deAccession")
     public String getDeAccession() {
         return deAccession;
     }

--- a/atlas-web/src/main/java/ae3/service/structuredquery/AtlasStructuredQueryService.java
+++ b/atlas-web/src/main/java/ae3/service/structuredquery/AtlasStructuredQueryService.java
@@ -1589,7 +1589,7 @@ public class AtlasStructuredQueryService {
         log.debug("Resulting EFVs are: " + resultEfvs.getNameSortedList().size());
         log.debug("Resulting EFOs are: " + resultEfos.getMarkedSubTreeList().size());
 
-    }
+            }
 
     /**
      * Loads experiments data for list view, where each list row corresponds to a single gene-ef-efv combination and each gene
@@ -1689,7 +1689,7 @@ public class AtlasStructuredQueryService {
                 closeQuietly(ewd);
             }
         }
-
+        
         if (showNonDEData) {
             // Now retrieve experiments in which geneId-ef-efv have NON_D_E expression
             scoringExps = atlasStatisticsQueryService.getScoringExperimentsForBioEntityAndAttribute(gene.getGeneId(), attr, StatisticsType.NON_D_E);
@@ -1739,7 +1739,7 @@ public class AtlasStructuredQueryService {
         }
         // If at least one experiment row was created add to result ListResultRow corresponding to geneId-ef-efv
         if (experimentsForRow.size() > 0) {
-            ListResultRow row = new ListResultRow(ef, efv, counter.getUps(), counter.getDowns(), counter.getNones(), pup, pdn, designElementAccession);
+            ListResultRow row = new ListResultRow(ef, efv, counter.getUps(), counter.getDowns(), counter.getNones(), pup, pdn);
             row.setGene(gene);
             row.setExp_list(experimentsForRow);
             result.addListResult(row);


### PR DESCRIPTION
Fixed a silly bug created by a heavy code refactoring during 'elimination parallel structures' change...

NetCDFProxyV2 methods getPValues(des) and getTStatistics(des) ignored the parameter 'des'.. and read all data every time from netCDF files...

Note: Need to be tested on the production data.. to compare the results..
