### PR TITLE
Trac3456

### DIFF
--- a/atlas-web/src/main/java/ae3/service/AtlasBitIndexQueryService.java
+++ b/atlas-web/src/main/java/ae3/service/AtlasBitIndexQueryService.java
@@ -330,15 +330,14 @@ public class AtlasBitIndexQueryService implements AtlasStatisticsQueryService {
                 if (!uniqueBestExperiments.contains(experimentResult))
                     uniqueBestExperiments.add(experimentResult);
             }
-            bestExperiments.addAll(uniqueBestExperiments);
+            return new ArrayList<ExperimentResult>(uniqueBestExperiments);
 
         } else {
             StatisticsQueryCondition statsQuery = new StatisticsQueryCondition(Collections.singleton(bioEntityId), statType);
             statsQuery.and(getStatisticsOrQuery(attributes, statType, 1));
             bestExperiments.addAll(getBestExperiments(statsQuery).values());
+            return bestExperiments;
         }
-
-        return bestExperiments;
     }
 
     /**

--- a/atlas-web/src/main/java/ae3/service/AtlasBitIndexQueryService.java
+++ b/atlas-web/src/main/java/ae3/service/AtlasBitIndexQueryService.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.*;
 
 import static com.google.common.collect.HashMultiset.create;
-import static com.google.common.collect.Maps.newHashMap;
 import static uk.ac.ebi.gxa.exceptions.LogUtil.createUnexpected;
 
 /**
@@ -325,11 +324,8 @@ public class AtlasBitIndexQueryService implements AtlasStatisticsQueryService {
             // Now retain only one ExperimentResult per experiment - the one with the best pVal/tStat rank
             // e.g. if experiment was present twice in bestExperiments (once for UP and once for DOWN)
             // we want to choose the one occurrence with the better best pVal/tStat rank
-            Set<ExperimentResult> uniqueBestExperiments = new LinkedHashSet<ExperimentResult>();
-            for (ExperimentResult experimentResult : bestExperiments) {
-                if (!uniqueBestExperiments.contains(experimentResult))
-                    uniqueBestExperiments.add(experimentResult);
-            }
+            Set<ExperimentResult> uniqueBestExperiments = new LinkedHashSet<ExperimentResult>(bestExperiments);
+
             return new ArrayList<ExperimentResult>(uniqueBestExperiments);
 
         } else {

--- a/atlas-web/src/main/java/ae3/service/AtlasBitIndexQueryService.java
+++ b/atlas-web/src/main/java/ae3/service/AtlasBitIndexQueryService.java
@@ -577,7 +577,9 @@ public class AtlasBitIndexQueryService implements AtlasStatisticsQueryService {
       *         statisticsQuery against statisticsStorage
       */
      private Map<Long, ExperimentResult> getBestExperiments(StatisticsQueryCondition statisticsQuery) {
-         Map<Long, ExperimentResult> bestExperimentsMap = newHashMap();
+         // Use LinkedHashMap to preserve the order to experiments - as they are populated from bit index
+         // in best-first order
+         Map<Long, ExperimentResult> bestExperimentsMap = new LinkedHashMap<Long, ExperimentResult>();
          getBestExperimentsRecursive(statisticsQuery, bestExperimentsMap);
          return bestExperimentsMap;
      }

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/requesthandlers/api/result/HeatmapResultAdapter.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/requesthandlers/api/result/HeatmapResultAdapter.java
@@ -154,15 +154,8 @@ public class HeatmapResultAdapter implements ApiQueryResults<HeatmapResultAdapte
             }
 
             Iterator<ExperimentResult> expiter() {
-                EfvAttribute attr = new EfvAttribute(efefv.getEf(), efefv.getEfv());
-                List<ExperimentResult> allExps = Lists.newArrayList();
-                if (getUpExperiments() > 0)
-                    allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.UP));
-                if (getDownExperiments() > 0)
-                    allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.DOWN));
-                if (getNonDEExperiments() > 0)
-                    allExps.addAll(toNonDEResults(atlasStatisticsQueryService.getScoringExperimentsForBioEntityAndAttribute(row.getGene().getGeneId(), attr, NON_D_E)));
-                return allExps.iterator();
+                return getExperimentResults(new EfvAttribute(efefv.getEf(), efefv.getEfv()), row.getGene().getGeneId(),
+                        getUpExperiments(), getDownExperiments(), getNonDEExperiments());
             }
         }
 
@@ -183,15 +176,8 @@ public class HeatmapResultAdapter implements ApiQueryResults<HeatmapResultAdapte
             }
 
             Iterator<ExperimentResult> expiter() {
-                Attribute attr = new EfoAttribute(efoItem.getId());
-                List<ExperimentResult> allExps = Lists.newArrayList();
-                if (getUpExperiments() > 0)
-                    allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.UP));
-                if (getDownExperiments() > 0)
-                    allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.DOWN));
-                if (getNonDEExperiments() > 0)
-                    allExps.addAll(toNonDEResults(atlasStatisticsQueryService.getScoringExperimentsForBioEntityAndAttribute(row.getGene().getGeneId(), attr, NON_D_E)));
-                return allExps.iterator();
+                return getExperimentResults(new EfoAttribute(efoItem.getId()), row.getGene().getGeneId(),
+                        getUpExperiments(), getDownExperiments(), getNonDEExperiments());
             }
         }
 
@@ -259,5 +245,16 @@ public class HeatmapResultAdapter implements ApiQueryResults<HeatmapResultAdapte
             results.add(new ExperimentResult(ei, null, NONDE_PTRANK));
         }
         return results;
+    }
+
+    private Iterator<ExperimentResult> getExperimentResults(Attribute attr, int geneId, int upExperimentsCnt, int downExperimentsCnt, int nondeExperimentsCnt) {
+        List<ExperimentResult> allExps = Lists.newArrayList();
+        if (upExperimentsCnt > 0)
+            allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(geneId, attr, -1, -1, StatisticsType.UP));
+        if (downExperimentsCnt > 0)
+            allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(geneId, attr, -1, -1, StatisticsType.DOWN));
+        if (nondeExperimentsCnt > 0)
+            allExps.addAll(toNonDEResults(atlasStatisticsQueryService.getScoringExperimentsForBioEntityAndAttribute(geneId, attr, NON_D_E)));
+        return allExps.iterator();
     }
 }

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/requesthandlers/api/result/HeatmapResultAdapter.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/requesthandlers/api/result/HeatmapResultAdapter.java
@@ -186,11 +186,11 @@ public class HeatmapResultAdapter implements ApiQueryResults<HeatmapResultAdapte
                 Attribute attr = new EfoAttribute(efoItem.getId());
                 List<ExperimentResult> allExps = Lists.newArrayList();
                 if (getUpExperiments() > 0)
-                 allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.UP));
-                 if (getDownExperiments() > 0)
-                allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.DOWN));
+                    allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.UP));
+                if (getDownExperiments() > 0)
+                    allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.DOWN));
                 if (getNonDEExperiments() > 0)
-                allExps.addAll(toNonDEResults(atlasStatisticsQueryService.getScoringExperimentsForBioEntityAndAttribute(row.getGene().getGeneId(), attr, NON_D_E)));
+                    allExps.addAll(toNonDEResults(atlasStatisticsQueryService.getScoringExperimentsForBioEntityAndAttribute(row.getGene().getGeneId(), attr, NON_D_E)));
                 return allExps.iterator();
             }
         }

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/requesthandlers/api/result/HeatmapResultAdapter.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/requesthandlers/api/result/HeatmapResultAdapter.java
@@ -48,7 +48,6 @@ import java.util.*;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static uk.ac.ebi.gxa.statistics.StatisticsType.NON_D_E;
-import static uk.ac.ebi.gxa.statistics.StatisticsType.UP_DOWN;
 import static uk.ac.ebi.gxa.utils.CollectionUtil.makeMap;
 
 /**
@@ -135,6 +134,17 @@ public class HeatmapResultAdapter implements ApiQueryResults<HeatmapResultAdapte
             }
 
             abstract Iterator<ExperimentResult> expiter();
+
+            protected Iterator<ExperimentResult> getExperimentResults(Attribute attr) {
+                List<ExperimentResult> allExps = Lists.newArrayList();
+                if (getUpExperiments() > 0)
+                    allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.UP));
+                if (getDownExperiments() > 0)
+                    allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.DOWN));
+                if (getNonDEExperiments() > 0)
+                    allExps.addAll(toNonDEResults(atlasStatisticsQueryService.getScoringExperimentsForBioEntityAndAttribute(row.getGene().getGeneId(), attr, NON_D_E)));
+                return allExps.iterator();
+            }
         }
 
         public class EfvExp extends ResultRow.Expression {
@@ -154,8 +164,7 @@ public class HeatmapResultAdapter implements ApiQueryResults<HeatmapResultAdapte
             }
 
             Iterator<ExperimentResult> expiter() {
-                return getExperimentResults(new EfvAttribute(efefv.getEf(), efefv.getEfv()), row.getGene().getGeneId(),
-                        getUpExperiments(), getDownExperiments(), getNonDEExperiments());
+                return getExperimentResults(new EfvAttribute(efefv.getEf(), efefv.getEfv()));
             }
         }
 
@@ -176,8 +185,7 @@ public class HeatmapResultAdapter implements ApiQueryResults<HeatmapResultAdapte
             }
 
             Iterator<ExperimentResult> expiter() {
-                return getExperimentResults(new EfoAttribute(efoItem.getId()), row.getGene().getGeneId(),
-                        getUpExperiments(), getDownExperiments(), getNonDEExperiments());
+                return getExperimentResults(new EfoAttribute(efoItem.getId()));
             }
         }
 
@@ -245,16 +253,5 @@ public class HeatmapResultAdapter implements ApiQueryResults<HeatmapResultAdapte
             results.add(new ExperimentResult(ei, null, NONDE_PTRANK));
         }
         return results;
-    }
-
-    private Iterator<ExperimentResult> getExperimentResults(Attribute attr, int geneId, int upExperimentsCnt, int downExperimentsCnt, int nondeExperimentsCnt) {
-        List<ExperimentResult> allExps = Lists.newArrayList();
-        if (upExperimentsCnt > 0)
-            allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(geneId, attr, -1, -1, StatisticsType.UP));
-        if (downExperimentsCnt > 0)
-            allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(geneId, attr, -1, -1, StatisticsType.DOWN));
-        if (nondeExperimentsCnt > 0)
-            allExps.addAll(toNonDEResults(atlasStatisticsQueryService.getScoringExperimentsForBioEntityAndAttribute(geneId, attr, NON_D_E)));
-        return allExps.iterator();
     }
 }

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/requesthandlers/api/result/HeatmapResultAdapter.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/requesthandlers/api/result/HeatmapResultAdapter.java
@@ -29,6 +29,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.ebi.gxa.dao.ExperimentDAO;
@@ -154,8 +155,13 @@ public class HeatmapResultAdapter implements ApiQueryResults<HeatmapResultAdapte
 
             Iterator<ExperimentResult> expiter() {
                 EfvAttribute attr = new EfvAttribute(efefv.getEf(), efefv.getEfv());
-                List<ExperimentResult> allExps = atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, UP_DOWN);
-                allExps.addAll(toNonDEResults(atlasStatisticsQueryService.getScoringExperimentsForBioEntityAndAttribute(row.getGene().getGeneId(), attr, NON_D_E)));
+                List<ExperimentResult> allExps = Lists.newArrayList();
+                if (getUpExperiments() > 0)
+                    allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.UP));
+                if (getDownExperiments() > 0)
+                    allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.DOWN));
+                if (getNonDEExperiments() > 0)
+                    allExps.addAll(toNonDEResults(atlasStatisticsQueryService.getScoringExperimentsForBioEntityAndAttribute(row.getGene().getGeneId(), attr, NON_D_E)));
                 return allExps.iterator();
             }
         }
@@ -178,7 +184,12 @@ public class HeatmapResultAdapter implements ApiQueryResults<HeatmapResultAdapte
 
             Iterator<ExperimentResult> expiter() {
                 Attribute attr = new EfoAttribute(efoItem.getId());
-                List<ExperimentResult> allExps = atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, UP_DOWN);
+                List<ExperimentResult> allExps = Lists.newArrayList();
+                if (getUpExperiments() > 0)
+                 allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.UP));
+                 if (getDownExperiments() > 0)
+                allExps.addAll(atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(row.getGene().getGeneId(), attr, -1, -1, StatisticsType.DOWN));
+                if (getNonDEExperiments() > 0)
                 allExps.addAll(toNonDEResults(atlasStatisticsQueryService.getScoringExperimentsForBioEntityAndAttribute(row.getGene().getGeneId(), attr, NON_D_E)));
                 return allExps.iterator();
             }

--- a/atlas-web/src/test/java/ae3/service/AtlasStatisticsQueryServiceTest.java
+++ b/atlas-web/src/test/java/ae3/service/AtlasStatisticsQueryServiceTest.java
@@ -249,6 +249,15 @@ public class AtlasStatisticsQueryServiceTest {
         assertNotNull(bestExperiment.getHighestRankAttribute().getEf());
         assertTrue(isSortedByPValTStatRank(list));
 
+        // If empty attribute is used, all scoring attributes are used for the query instead; but scoring attributes are stored in bit index for StatisticsType.UP_DOWN only
+        efvAttr = new EfvAttribute("", "");
+        list = atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(bioEntityId, efvAttr, -1, -1, StatisticsType.UP);
+        assertNotNull(list);
+        assertEquals(0, list.size());
+        list = atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(bioEntityId, efvAttr, -1, -1, StatisticsType.DOWN);
+        assertNotNull(list);
+        assertEquals(0, list.size());
+
         EfAttribute efAttr = new EfAttribute("");
         list = atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(bioEntityId, efAttr, -1, -1, StatisticsType.UP_DOWN);
         assertNotNull(list);
@@ -274,11 +283,27 @@ public class AtlasStatisticsQueryServiceTest {
         assertTrue(list3.size() > 0);
         assertTrue(isSortedByPValTStatRank(list3));
 
+        efvAttr = new EfvAttribute("organism_part", "liver");
+        list3 = atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(bioEntityId, efvAttr, -1, -1, StatisticsType.DOWN);
+        assertNotNull(list3);
+        assertTrue(list3.size() > 0);
+        assertTrue(isSortedByPValTStatRank(list3));
+
         efAttr = new EfAttribute("organism_part");
         list3 = atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(bioEntityId, efAttr, -1, -1, StatisticsType.UP_DOWN);
         assertNotNull(list3);
         assertTrue(list3.size() > 0);
         assertTrue(isSortedByPValTStatRank(list3));
+
+        // For EfAttribute, we store pval/tstat ranks only for StatisticsType.UP_DOWN
+        efAttr = new EfAttribute("organism_part");
+        list3 = atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(bioEntityId, efAttr, -1, -1, StatisticsType.UP);
+        assertNotNull(list3);
+        assertEquals(0, list3.size());
+        efAttr = new EfAttribute("organism_part");
+        list3 = atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(bioEntityId, efAttr, -1, -1, StatisticsType.DOWN);
+        assertNotNull(list3);
+        assertEquals(0, list3.size());
     }
 
     @Test

--- a/atlas-web/src/test/java/ae3/service/AtlasStatisticsQueryServiceTest.java
+++ b/atlas-web/src/test/java/ae3/service/AtlasStatisticsQueryServiceTest.java
@@ -299,11 +299,12 @@ public class AtlasStatisticsQueryServiceTest {
         efAttr = new EfAttribute("organism_part");
         list3 = atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(bioEntityId, efAttr, -1, -1, StatisticsType.UP);
         assertNotNull(list3);
-        assertEquals(0, list3.size());
+        assertTrue(list3.size() > 0);
+        assertTrue(isSortedByPValTStatRank(list3));
         efAttr = new EfAttribute("organism_part");
         list3 = atlasStatisticsQueryService.getExperimentsSortedByPvalueTRank(bioEntityId, efAttr, -1, -1, StatisticsType.DOWN);
-        assertNotNull(list3);
-        assertEquals(0, list3.size());
+        assertTrue(list3.size() > 0);
+        assertTrue(isSortedByPValTStatRank(list3));
     }
 
     @Test


### PR DESCRIPTION
- Split experiments queries into separate UP and DOWN expression ones
- Modified to fetch experiments for a given expression type only if the counter reports any for that expression type. 

This will both prevent nonde expression experiments being output if the user hadn't queried for them, but will also make the API queries faster - but avoiding to unnecessarily query for experiments if we already know that none can be found.

@nsklyar - could you review please
