### PR TITLE
Ticket 2868 

### DIFF
--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/web/filter/HealthFilter.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/web/filter/HealthFilter.java
@@ -1,0 +1,42 @@
+package uk.ac.ebi.gxa.web.filter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import javax.servlet.*;
+
+/**
+ * In London Data Centres external services direct their load balancing by issuing a 'health' web request to each of four
+ * London Atlas data servers every 3 seconds. If a given server does not respond 3 times in a row (i.e. over a period of 9 seconds)
+ * the load-balancer re-directs traffic to the remaining Atlas servers.
+ * <p/>
+ * Given this ES 'health' requests will be very frequent, we don't want them to pollute access logs. Atlas servers in London therefore
+ * have a Valve defined in server.xml that prevents writing to access log requests for which attribute "health" has been set (c.f. doFilter()
+ * method below).
+ * <p/>
+ * C.f. web.xml for which type of request this filter applies to.
+ *
+ * @author Robert Petryszak
+ */
+public class HealthFilter implements Filter {
+    private static final Logger log = LoggerFactory.getLogger(HealthFilter.class);
+
+    public HealthFilter() {
+    }
+
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        request.setAttribute("health", Boolean.valueOf(true));
+        chain.doFilter(request, response);
+    }
+
+    public void init(FilterConfig filterconfig)
+            throws ServletException {
+        log.debug("init");
+    }
+
+    public void destroy() {
+        log.debug("destroy");
+    }
+}

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/web/filter/HealthFilter.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/web/filter/HealthFilter.java
@@ -27,7 +27,7 @@ public class HealthFilter implements Filter {
 
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        request.setAttribute("health", Boolean.TRUE);
+        request.setAttribute("health", true);
         chain.doFilter(request, response);
     }
 

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/web/filter/HealthFilter.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/web/filter/HealthFilter.java
@@ -27,7 +27,7 @@ public class HealthFilter implements Filter {
 
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        request.setAttribute("health", Boolean.valueOf(true));
+        request.setAttribute("health", Boolean.TRUE);
         chain.doFilter(request, response);
     }
 

--- a/atlas-web/src/main/webapp/WEB-INF/web.xml
+++ b/atlas-web/src/main/webapp/WEB-INF/web.xml
@@ -456,6 +456,11 @@
     </filter>
 
     <filter>
+        <filter-name>HealthFilter</filter-name>
+        <filter-class>uk.ac.ebi.gxa.web.filter.HealthFilter</filter-class>
+    </filter>
+
+    <filter>
         <filter-name>SimplePageFragmentCachingFilter</filter-name>
         <filter-class>net.sf.ehcache.constructs.web.filter.SimplePageFragmentCachingFilter</filter-class>
         <init-param>
@@ -467,6 +472,11 @@
             <param-value>SimplePageFragmentCachingFilter</param-value>
         </init-param>
     </filter>
+
+    <filter-mapping>
+        <filter-name>HealthFilter</filter-name>
+        <url-pattern>/webping</url-pattern>
+    </filter-mapping>
 
     <filter-mapping>
         <filter-name>NoCacheHeaderFilter</filter-name>


### PR DESCRIPTION
Added filter to be used to prevent logging in access.log of 'service health'-requests - used by External Services load balancer in London Data Centre.

@nsklyar - could you review please?
