### PR TITLE
Ticket 3483 - Fixed gene autocomplete in the simple search form. 

### DIFF
--- a/atlas-web/src/main/webapp/scripts/jquery-token-autocomplete/jquery.token.autocomplete.js
+++ b/atlas-web/src/main/webapp/scripts/jquery-token-autocomplete/jquery.token.autocomplete.js
@@ -111,6 +111,7 @@ $.TokenList = function (input, settings) {
 
     // Create a new text input an attach keyup events
     var input_box = $("<input type='text'>")
+        .attr('id', settings.extraParams.type)
         .attr('autocomplete', 'off')
         .val(previousValue = (settings.defaultValue ? settings.defaultValue : ''))
         .focus(function () {


### PR DESCRIPTION
Now:
1. Only items chosen from autocomplete get tokenized;
2. If the user searches for a non-autocompleted gene condition, and they click on 'search' again on the heatmap page, that item no longer 'magically' acquire a property (e.g. 'ensembl family description' )- thus changing the query under the user's feet. 
3. Previously one one property was used for all the autocompleted values in the gene input field - disregarding individual properties chosen by the user in the autocomplete - now property for each autocompleted item is preserved.
