### PR TITLE
Ticket 3174

### DIFF
--- a/atlas-web/src/main/java/ae3/dao/GeneSolrDAO.java
+++ b/atlas-web/src/main/java/ae3/dao/GeneSolrDAO.java
@@ -177,7 +177,7 @@ public class GeneSolrDAO {
      * @param additionalIds additional properties to search for
      * @return Iterable<AtlasGene>
      */
-    private Iterable<AtlasGene> getGenesByAnyIdentifiers(Collection<String> ids, List<String> additionalIds) {
+    public Iterable<AtlasGene> getGenesByAnyIdentifiers(Collection<String> ids, List<String> additionalIds) {
         if (ids.isEmpty()) return Collections.emptyList();
 
         StringBuilder sb = new StringBuilder();

--- a/atlas-web/src/main/java/ae3/service/AtlasBitIndexQueryService.java
+++ b/atlas-web/src/main/java/ae3/service/AtlasBitIndexQueryService.java
@@ -566,6 +566,16 @@ public class AtlasBitIndexQueryService implements AtlasStatisticsQueryService {
     }
 
     /**
+     *
+     * @param statisticsType
+     * @param bioEntityId
+     * @return true if bioEntityId has any scores across all EFO's for statisticsType; false otherwise
+     */
+    public boolean isScoringBioEntity(StatisticsType statisticsType, Integer bioEntityId) {
+        return StatisticsQueryUtils.getScoresAcrossAllEfos(statisticsType, statisticsStorage).contains(bioEntityId);
+    }
+
+    /**
       * Populate bestExperimentsSoFar with an (unsorted) list of experiments with best pval/tstat rank, for statisticsQuery
       *
       * @param statisticsQuery

--- a/atlas-web/src/main/java/ae3/service/AtlasStatisticsQueryService.java
+++ b/atlas-web/src/main/java/ae3/service/AtlasStatisticsQueryService.java
@@ -221,4 +221,12 @@ public interface AtlasStatisticsQueryService extends IndexBuilderEventHandler, D
      */
     public int getMappingsCountForEfo(String efoTerm);
 
+    /**
+     *
+     * @param statisticsType
+     * @param bioEntityId
+     * @return true if bioEntityId has any scores across all EFO's for statisticsType; false otherwise
+     */
+    public boolean isScoringBioEntity(StatisticsType statisticsType, Integer bioEntityId);
+
 }

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/requesthandlers/query/AtlasQueryRequestHandler.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/requesthandlers/query/AtlasQueryRequestHandler.java
@@ -101,6 +101,13 @@ public class AtlasQueryRequestHandler implements HttpRequestHandler, IndexBuilde
             }
 
             atlasResult = queryService.doStructuredAtlasQuery(atlasQuery);
+            // if one scoring gene only found and user didn't restrict the search, skip through to gene page
+            if (atlasResult.getSize() == 1 && !atlasQuery.isRestricted()) {
+                StructuredResultRow row = atlasResult.getResults().iterator().next();
+                String url = "gene/" + row.getGene().getGeneIdentifier();
+                response.sendRedirect(url);
+                return;
+            }
         } else {
             atlasResult = new AtlasStructuredQueryResult(0, 0, 0);
         }


### PR DESCRIPTION
 Modfied not to show single heatmap row in gxa/gene/geneid cases where geneid matches more than one gene in Solr, but only one gene is UP_DOWN scoring in bitindex. In such cases, the user stays on gene page - as used to be the case and as is expected by users - according to the feedback from FG trainers.
