### PR TITLE
Ticket 3493 - Made oligo library the default for normalizing experiments loaded into Atlas

### DIFF
--- a/atlas-loader/src/main/java/uk/ac/ebi/gxa/loader/service/AtlasMAGETABLoader.java
+++ b/atlas-loader/src/main/java/uk/ac/ebi/gxa/loader/service/AtlasMAGETABLoader.java
@@ -135,7 +135,13 @@ public class AtlasMAGETABLoader {
                 Collection<String> useRawData = cmd.getUserData().get("useRawData");
                 if (useRawData != null && useRawData.size() == 1 && "true".equals(useRawData.iterator().next())) {
                     logProgress(listener, 5, ArrayDataStep.displayName());
-                    arrayDataRead = new ArrayDataStep().readArrayData(atlasComputeService, investigation, listener, cache, dao);
+                    String normalizationMode;
+                    Collection<String> libs = cmd.getUserData().get("normalizationMode");
+                    if (libs == null || libs.isEmpty())
+                        normalizationMode = "oligo";
+                    else
+                        normalizationMode = libs.iterator().next();
+                    arrayDataRead = new ArrayDataStep().readArrayData(atlasComputeService, investigation, listener, cache, dao, normalizationMode);
                 }
 
                 logProgress(listener, 6, DerivedArrayDataMatrixStep.displayName());

--- a/atlas-loader/src/main/java/uk/ac/ebi/gxa/loader/steps/ArrayDataStep.java
+++ b/atlas-loader/src/main/java/uk/ac/ebi/gxa/loader/steps/ArrayDataStep.java
@@ -343,7 +343,7 @@ public class ArrayDataStep {
             scans.append(")");
             log.info(files.toString());
             log.info(scans.toString());
-            log.info("mode :" + normalizationMode);
+            log.info("mode:" + normalizationMode);
             log.info("outFile = '" + mergedFilePath + "'");
             R.sourceFromBuffer(files.toString());
             R.sourceFromBuffer(scans.toString());

--- a/atlas-loader/src/main/resources/R/normalizeOneExperiment.R
+++ b/atlas-loader/src/main/resources/R/normalizeOneExperiment.R
@@ -2,43 +2,66 @@
 # scans <- a list of corresponding scan names (should have the same length)
 # outFile <- a name of file to store normalized data
 # parallel <- run a parlallelized version of normalization script (requires affyParaEBI R package)
+# mode <- affy or oligo
+normalizeOneExperiment <- function(files, outFile, scans, mode) {
+	  error <- try({
+	        if(mode == "oligo") {
 
-normalizeOneExperiment <- function(files, outFile, scans, parallel = FALSE) {
-  error <- try({
-    library(affy)
+	                # load oligo
+	                library(oligo)
 
-    es <- NULL
-    if (parallel) {
-      ae <- ReadAffy(filenames = files)
+	                # Call all oligo functions explicitly with "oligo::function" -- some
+	                # seem to get masked by other packages (affy and limma). Probably
+	                # doesn't matter if just running one expt at a time.
 
-      library(affyParaEBI)
-      numClusters <- 10 #Change this if you have few assays than clusters or if you want to speed up the process
-      cluster <- makeCluster(numClusters, type = "RCLOUD")
-      numClusters <- length(cluster)
-      cluster <- clusterOptimization(cluster, substitute = TRUE) #this will replace possible low performance clusters 
-      es <- preproParaEBI(path = filesPath, cluster = cluster)       #this preforms the preprocessing
-      dim(exprs(es))
-      mean(exprs(es))
-    } else {
-      print("Running justRMA")
-      es <- justRMA(filenames = files, celfile.path = NULL)
-      print("justRMA finished")
-    }
+	                # Read in data from cel files. oligo doesn't seem to have an equivalent of
+	                # affy's justRMA which will read in cel files and do the normalization.
+	                print("Reading in CEL files")
+	                featureSet <- oligo::read.celfiles(files)
 
-    relSort <- function(toSort, keys, sortedKeys) {
-       sorted <- toSort
-       for (i in 1:length(sortedKeys)) sorted[i] <- toSort[which(keys==sortedKeys[i])]
-       return(sorted)
-    }
+	                # run RMA using oligo::rma function.
+	                print("Running rma")
 
-    len <- length(sampleNames(es))
-    shortFileNames <- gsub(".+/", "", files)
-    scansSorted <- relSort(scans, shortFileNames, sampleNames(es))
-    write(c("Scan REF", scansSorted), outFile, ncolumns = len+1, sep = "\t")
-    write(c("Composite Element REF", rep("GEO:AFFYMETRIX_VALUE", len)), outFile, ncolumns = len+1, sep="\t", append=TRUE)
-    #featureNames(es) = paste("Affymetrix:CompositeSequence:HG-U133_Plus_2:", featureNames(es), sep = "")
-    write.table(exprs(es), file = outFile, sep = "\t", quote = FALSE, row.names = TRUE, col.names = FALSE, append = TRUE)
-  })
+	                # For ST arrays (ExonFeatureSet or GeneFeatureSet), the target argument is needed.
+	                # target="core" obtains gene-level summaries of expression -- and for
+	                # now we want to display information for genes, we are not going as far as
+	                # individual exons.
+	                # For non-ST arrays (ExpressionFeatureSet or SnpCnvFeatureSet), do not
+	                # specify target (dies if you do).
+	                if( grepl("Gene", class(featureSet)[1]) || grepl("Exon", class(featureSet[1]) )) {
+	                        es <- oligo::rma(featureSet, target="core")
+	                } else {
+	                        es <- oligo::rma(featureSet)    # non-ST arrays, no target
+	                }
+	                print("rma finished")
+
+	        } else if(mode == "affy") {
+
+	                # load affy
+	                library(affy)
+
+	                # read in cel files and normalize using justRMA
+	                print("Running justRMA")
+	                es <- justRMA(filenames = files, celfile.path = NULL)
+	                print("justRMA finished")
+	        }
+
+	        # function to sort the source names (in scans) so they are in the correct
+	        # order for the data in es
+	       relSort <- function(toSort, keys, sortedKeys) {
+	          sorted <- toSort
+	          for (i in 1:length(sortedKeys)) sorted[i] <- toSort[which(keys==sortedKeys[i])]
+	          return(sorted)
+	       }
+
+	    len <- length(sampleNames(es))
+	    shortFileNames <- gsub(".+/", "", files)
+	    scansSorted <- relSort(scans, shortFileNames, sampleNames(es))
+	    write(c("Scan REF", scansSorted), outFile, ncolumns = len+1, sep = "\t")
+	    write(c("Composite Element REF", rep("GEO:AFFYMETRIX_VALUE", len)), outFile, ncolumns = len+1, sep="\t", append=TRUE)
+	    #featureNames(es) = paste("Affymetrix:CompositeSequence:HG-U133_Plus_2:", featureNames(es), sep = "")
+	    write.table(exprs(es), file = outFile, sep = "\t", quote = FALSE, row.names = TRUE, col.names = FALSE, append = TRUE)
+	  })
   if ("try-error" == class(error)) {
     return(error)
   } else {

--- a/atlas-web/src/main/webapp/admin.html
+++ b/atlas-web/src/main/webapp/admin.html
@@ -443,6 +443,16 @@
                     <input type="checkbox" id="useRawData" checked="checked">
                     <label for="useRawData">Use raw experimental data if possible</label>
                 </td>
+            </tr>
+            <tr>
+                <td></td>
+                <td> Use:
+                    <select id="normalizationMode">
+                        <option value="oligo">oligo</option>
+                        <option value="affy">affy</option>
+                    </select>
+                    mode for experiment normalisation
+                </td>
                 <td style="text-align:right">
                     <input type="button" value="Load" id="loadButton">
                 </td>

--- a/atlas-web/src/main/webapp/scripts/admin.js
+++ b/atlas-web/src/main/webapp/scripts/admin.js
@@ -1288,6 +1288,7 @@ $(document).ready(function () {
     $('#loadButton').click(function () {
         var url = $('#loadUrl').val().replace(/^\s+/,'').replace(/\s+$/,'').split(/\s+/);
         var type = $('#loadType').val();
+        var normalizationMode = $('#normalizationMode').val();
         var autoDep = $('#loadAutodep').is(':checked');
         var useRawData = $('#useRawData').is(':checked');
         var private = $('#private').is(':checked');
@@ -1313,6 +1314,7 @@ $(document).ready(function () {
                     type: 'loadexperiment',
                     autoDepends: autoDep,
                     useRawData: useRawData,
+                    normalizationMode : normalizationMode,
                     private: private
                 }, updateQueueAndLog);
 


### PR DESCRIPTION
Made oligo library the default for normalizing experiments loaded into Atlas; affy library can still be selected if needed. Additionally, remove parallel affy section from normalizeOneExperiment.R - we never use it. It's also never been proven that it yields the same results as the standard (non-parallel) affy library
