### PR TITLE
Trac3509

### DIFF
--- a/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/PropertyDAO.java
+++ b/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/PropertyDAO.java
@@ -72,6 +72,13 @@ public class PropertyDAO extends AbstractDAO<Property> {
         return results;
     }
 
+    public boolean isPropertyUsed(String propertyName) {
+        if (!template.find("from Assay a left join a.properties p where p.propertyValue.property.name = ?", propertyName).isEmpty() ||
+                !template.find("from Sample s left join s.properties p where p.propertyValue.property.name = ?", propertyName).isEmpty())
+            return true;
+        return false;
+    }
+
     /**
      * Remove all properties that are not referenced in any assay/sample
      */

--- a/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/PropertyValueDAO.java
+++ b/atlas-dao/src/main/java/uk/ac/ebi/gxa/dao/PropertyValueDAO.java
@@ -71,6 +71,13 @@ public class PropertyValueDAO extends AbstractDAO<PropertyValue> {
         return results;
     }
 
+    public boolean isPropertyValueUsed(String propertyName, String propertyValue) {
+        if (!template.find("from Assay a left join a.properties p where p.propertyValue.property.name = ? and p.propertyValue.value = ?", propertyName, propertyValue).isEmpty() ||
+                !template.find("from Sample s left join s.properties p where p.propertyValue.property.name = ? and p.propertyValue.value = ?", propertyName, propertyValue).isEmpty())
+            return true;
+        return false;
+    }
+
     /**
      * @return remove PropertyValue's that are not referenced in any assay/sample
      */

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/service/CurationService.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/service/CurationService.java
@@ -275,7 +275,6 @@ public class CurationService {
                     log.warn("Not removing property: " + propertyName + " as still used in assays or samples");
             else {
                 if (!propertyValueDAO.isPropertyValueUsed(propertyName, propertyValue)) {
-
                     Property property = propertyDAO.getByName(propertyName);
                     PropertyValue propValue = propertyValueDAO.find(property, propertyValue);
                     propertyDAO.delete(property, propValue);

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/service/CurationService.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/service/CurationService.java
@@ -246,7 +246,7 @@ public class CurationService {
      * @throws ResourceNotFoundException
      */
     @Transactional
-    public void deleteProperty(final String propertyName) throws ResourceNotFoundException {
+    private void deleteProperty(final String propertyName) throws ResourceNotFoundException {
         try {
             Property property = propertyDAO.getByName(propertyName);
             propertyDAO.delete(property);

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/service/CurationService.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/service/CurationService.java
@@ -12,6 +12,8 @@ import uk.ac.ebi.gxa.exceptions.ResourceNotFoundException;
 import uk.ac.ebi.gxa.utils.Pair;
 import uk.ac.ebi.microarray.atlas.api.*;
 import uk.ac.ebi.microarray.atlas.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -26,6 +28,7 @@ import static com.google.common.collect.Collections2.transform;
  */
 @Service
 public class CurationService {
+    final private Logger log = LoggerFactory.getLogger(this.getClass());
     @Autowired
     private AtlasDAO atlasDAO;
 
@@ -266,11 +269,20 @@ public class CurationService {
         try {
 
             if (Strings.isNullOrEmpty(propertyValue))
-                deleteProperty(propertyName);
+                if (!propertyDAO.isPropertyUsed(propertyName))
+                    deleteProperty(propertyName);
+                else
+                    log.warn("Not removing property: " + propertyName + " as still used in assays or samples");
             else {
-                Property property = propertyDAO.getByName(propertyName);
-                PropertyValue propValue = propertyValueDAO.find(property, propertyValue);
-                propertyDAO.delete(property, propValue);
+                if (!propertyValueDAO.isPropertyValueUsed(propertyName, propertyValue)) {
+
+                    Property property = propertyDAO.getByName(propertyName);
+                    PropertyValue propValue = propertyValueDAO.find(property, propertyValue);
+                    propertyDAO.delete(property, propValue);
+                } else {
+                    log.warn("Not removing property: " + propertyName +
+                            " and propertyValue: " + propertyValue + " as still used in assays or samples");
+                }
             }
         } catch (RecordNotFoundException e) {
             throw convert(e);

--- a/atlas-web/src/main/java/uk/ac/ebi/gxa/web/controller/api/CurationApiController.java
+++ b/atlas-web/src/main/java/uk/ac/ebi/gxa/web/controller/api/CurationApiController.java
@@ -103,6 +103,10 @@ public class CurationApiController extends AtlasViewController {
         log.info("User: '" + request.getRemoteUser() +
                 "' replaced property value: '" + oldPropertyValue + "' with new value: '" + newPropertyValue +
                 "' for property: '" + propertyName + "' in all experiments");
+        curationService.deletePropertyOrValue(propertyName, oldPropertyValue);
+        log.info("User: '" + request.getRemoteUser() +
+                "' deleted property: '" + propertyName +
+                "'" + (!Strings.isNullOrEmpty(oldPropertyValue) ? " and value: '" + oldPropertyValue + "'" : ""));
     }
 
     @RequestMapping(value = "/properties/{oldPropertyName}/{newPropertyName}",
@@ -118,6 +122,8 @@ public class CurationApiController extends AtlasViewController {
         curationService.replacePropertyInExperiments(oldPropertyName, newPropertyName);
         log.info("User: '" + request.getRemoteUser() +
                 "' replaced property: '" + oldPropertyName + "' with new property: '" + newPropertyName + "' in all experiments");
+        curationService.deletePropertyOrValue(oldPropertyName, null);
+        log.info("User: '" + request.getRemoteUser() + "' deleted property: '" + oldPropertyName);
     }
 
     @RequestMapping(value = "/propertyvaluemappings/exactmatch/{propertyName}.json",

--- a/atlas-web/src/test/java/uk/ac/ebi/gxa/service/TestCurationService.java
+++ b/atlas-web/src/test/java/uk/ac/ebi/gxa/service/TestCurationService.java
@@ -37,6 +37,8 @@ public class TestCurationService extends AtlasDAOTestCase {
     private static final String VALUE007 = "value007";
     private static final String VALUE004 = "value004";
     private static final String VALUE010 = "value010";
+    private static final String UNUSED_PROPERTY = "unused";
+    private static final String UNUSED_PROPERTYVALUE = "unused_val";
     private static final String MICROGLIAL_CELL = "microglial cell";
     private static final String E_MEXP_420 = "E-MEXP-420";
     private static final String ASSAY_ACC = "abc:ABCxyz:SomeThing:1234.ABC123";
@@ -477,16 +479,31 @@ public class TestCurationService extends AtlasDAOTestCase {
         curationService.deletePropertyOrValue(CELL_TYPE, VALUE007);
         curationService.deletePropertyOrValue(PROP3, VALUE004);
 
-        assertFalse("Property : " + CELL_TYPE + ":" + VALUE007 + " not removed from assay properties",
+        assertTrue("Property : " + CELL_TYPE + ":" + VALUE007 + " was removed from assay properties",
                 propertyPresent(curationService.getAssayProperties(E_MEXP_420, ASSAY_ACC), CELL_TYPE, VALUE007));
-        assertFalse("Property : " + PROP3 + ":" + VALUE004 + " not removed from sample properties",
+        assertTrue("Property : " + PROP3 + ":" + VALUE004 + " was removed from sample properties",
                 propertyPresent(curationService.getSampleProperties(E_MEXP_420, SAMPLE_ACC), PROP3, VALUE004));
 
+        // The removal of CELL_TYPE:VALUE007 and PROP3:VALUE004 dit not succeed because they were still being used in some assays or samples
         Collection<ApiPropertyValue> propertyValues = curationService.getPropertyValues(CELL_TYPE);
-        assertFalse("Property value: " + VALUE007 + " found", Collections2.transform(propertyValues, PROPERTY_VALUE_FUNC).contains(VALUE007));
-
+        assertTrue("Property value: " + VALUE007 + " not found", Collections2.transform(propertyValues, PROPERTY_VALUE_FUNC).contains(VALUE007));
         propertyValues = curationService.getPropertyValues(PROP3);
-        assertFalse("Property value: " + VALUE004 + " found", Collections2.transform(propertyValues, PROPERTY_VALUE_FUNC).contains(VALUE004));
+        assertTrue("Property value: " + VALUE004 + " not found", Collections2.transform(propertyValues, PROPERTY_VALUE_FUNC).contains(VALUE004));
+    }
+
+    @Test
+    public void testDeletePropertyValue1() throws Exception {
+        assertFalse("Property : " + UNUSED_PROPERTY + ":" + UNUSED_PROPERTYVALUE + " found in assay properties",
+                propertyPresent(curationService.getAssayProperties(E_MEXP_420, ASSAY_ACC), UNUSED_PROPERTY, UNUSED_PROPERTYVALUE));
+        assertFalse("Property : " + UNUSED_PROPERTYVALUE + ":" + UNUSED_PROPERTYVALUE + " found in sample properties",
+                propertyPresent(curationService.getSampleProperties(E_MEXP_420, SAMPLE_ACC), UNUSED_PROPERTY, UNUSED_PROPERTYVALUE));
+
+        curationService.deletePropertyOrValue(UNUSED_PROPERTY, UNUSED_PROPERTYVALUE);
+
+        // The removal of UNUSED_PROPERTY:UNUSED_PROPERTYVALUE succeeded as it had not been used in any assays or samples
+        Collection<ApiPropertyValue> propertyValues = curationService.getPropertyValues(UNUSED_PROPERTY);
+        assertFalse("Property value: " + UNUSED_PROPERTYVALUE + " not found", Collections2.transform(propertyValues, PROPERTY_VALUE_FUNC).contains(UNUSED_PROPERTYVALUE));
+
     }
 
     @Test
@@ -494,9 +511,24 @@ public class TestCurationService extends AtlasDAOTestCase {
         Collection<ApiPropertyName> propertyNames = curationService.getPropertyNames();
         assertTrue("Property: " + CELL_TYPE + " not found", Collections2.transform(propertyNames, PROPERTY_NAME_FUNC).contains(CELL_TYPE));
         curationService.deletePropertyOrValue(CELL_TYPE, null);
+        // The removal of property CELL_TYPE was unsuccessful as it was still being used in some assays or samples
         propertyNames = curationService.getPropertyNames();
-        assertFalse("Property: " + CELL_TYPE + " not removed", Collections2.transform(propertyNames, PROPERTY_NAME_FUNC).contains(CELL_TYPE));
+        assertTrue("Property: " + CELL_TYPE + " was incorrectly removed", Collections2.transform(propertyNames, PROPERTY_NAME_FUNC).contains(CELL_TYPE));
+    }
 
+    @Test
+    public void testDeleteProperty1() throws Exception {
+        assertFalse("Property : " + UNUSED_PROPERTY + ":" + UNUSED_PROPERTYVALUE + " found in assay properties",
+                propertyPresent(curationService.getAssayProperties(E_MEXP_420, ASSAY_ACC), UNUSED_PROPERTY, UNUSED_PROPERTYVALUE));
+        assertFalse("Property : " + UNUSED_PROPERTYVALUE + ":" + UNUSED_PROPERTYVALUE + " found in sample properties",
+                propertyPresent(curationService.getSampleProperties(E_MEXP_420, SAMPLE_ACC), UNUSED_PROPERTY, UNUSED_PROPERTYVALUE));
+
+        Collection<ApiPropertyName> propertyNames = curationService.getPropertyNames();
+        assertTrue("Property: " + CELL_TYPE + " not found", Collections2.transform(propertyNames, PROPERTY_NAME_FUNC).contains(UNUSED_PROPERTY));
+        curationService.deletePropertyOrValue(CELL_TYPE, null);
+        // The removal of UNUSED_PROPERTY succeeded as it had not been used in any assays or samples
+        propertyNames = curationService.getPropertyNames();
+        assertTrue("Property: " + UNUSED_PROPERTY + " was not removed", Collections2.transform(propertyNames, PROPERTY_NAME_FUNC).contains(UNUSED_PROPERTY));
     }
 
     @Test


### PR DESCRIPTION
Modified to remove the property/value right after it was replaced by a new property/value in all assays/samples. As an added safety measure, a property/value is removed only if it is not used in any assays/samples.
